### PR TITLE
Add babel-plugin-styled-components to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@bcgov/bc-sans": "^1.0.1",
         "@reach/skip-nav": "^0.17.0",
+        "babel-plugin-styled-components": "^2.0.7",
         "gatsby": "^4.12.1",
         "gatsby-plugin-catch-links": "^4.12.1",
         "gatsby-plugin-image": "^2.12.1",
@@ -5327,7 +5328,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
       "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
@@ -5342,8 +5342,7 @@
     "node_modules/babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "peer": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -24795,7 +24794,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
       "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
-      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
@@ -24807,8 +24805,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "peer": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@bcgov/bc-sans": "^1.0.1",
     "@reach/skip-nav": "^0.17.0",
+    "babel-plugin-styled-components": "^2.0.7",
     "gatsby": "^4.12.1",
     "gatsby-plugin-catch-links": "^4.12.1",
     "gatsby-plugin-image": "^2.12.1",


### PR DESCRIPTION
This pull request adds `babel-plugin-styled-components` to `./package.json` (a10701e) to fix the following error from `gatsby build`:

```
[2K[1A[2K[Gsuccess load gatsby config - 0.399s

[2K[1A[2K[G
 ERROR

Error in
"/opt/app-root/src/node_modules/gatsby-plugin-styled-components/gatsby-node.js":
 'babel-plugin-styled-components' is not installed which is needed by plugin
'gatsby-plugin-styled-components'
```