### PR TITLE
Use more specific nginx version in production Dockerfile

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -9,6 +9,6 @@ COPY . .
 RUN ["npm", "run", "build"]
 
 
-FROM nginx
+FROM ubi8/nginx-120
 EXPOSE 80
 COPY --from=builder /app/public /usr/share/nginx/html


### PR DESCRIPTION
This pull request updates the production Dockerfile (`./Dockerfile.prod`) to point to Red Hat's [`ubi8/nginx-120` nginx image](https://catalog.redhat.com/software/containers/ubi8/nginx-120/6156abfac739c0a4123a86fd). (a581096)