### PR TITLE
Use nginx tag 1.18-ubi8 in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -9,6 +9,6 @@ COPY . .
 RUN ["npm", "run", "build"]
 
 
-FROM ubi8/nginx-120
+FROM nginx:1.18-ubi8
 EXPOSE 80
 COPY --from=builder /app/public /usr/share/nginx/html


### PR DESCRIPTION
This pull request changes the nginx version used in `./Dockerfile.prod` to reference a currently available tag in OpenShift, `1.18-ubi8`.