### PR TITLE
Use nginx without a version tag in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -9,6 +9,6 @@ COPY . .
 RUN ["npm", "run", "build"]
 
 
-FROM nginx:1.18-ubi8
+FROM nginx
 EXPOSE 80
 COPY --from=builder /app/public /usr/share/nginx/html


### PR DESCRIPTION
This pull request reverts changes to `./Dockerfile.prod` by using nginx without a specific version tag.