### PR TITLE
Add nginx.conf for use with Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -10,5 +10,7 @@ RUN ["npm", "run", "build"]
 
 
 FROM nginx
-EXPOSE 80
+COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/public /usr/share/nginx/html
+EXPOSE 8080:8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -5,4 +5,4 @@ services:
       context: .
       dockerfile: Dockerfile.prod
     ports:
-      - "80:80"
+      - "8080:8080"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,32 @@
+# nginx.conf
+# Adapted from https://cloud.redhat.com/blog/deploy-vuejs-applications-on-openshift
+worker_processes auto;
+
+pid /tmp/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types; 
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path       /tmp/proxy_temp_path;
+  fastcgi_temp_path     /tmp/fastcgi_temp;
+  uwsgi_temp_path       /tmp/uwsgi_temp;
+  scgi_temp_path        /tmp/scgi_temp;
+
+  server {
+    listen 8080;
+    server_name _;
+
+    index index.html;
+    error_log  /tmp/error.log;
+    access_log /tmp/access.log;
+
+    location / {
+      root /usr/share/nginx/html;
+      try_files $uri /index.html;
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds an `./nginx.conf` configuration file for use along with the OpenShift-focused `./Dockerfile.prod`. It changes the nginx port from 80 to 8080 to avoid root user access issues on OpenShift. This strategy is adopted from RedHat's [Deploy VueJS applications on OpenShift](https://cloud.redhat.com/blog/deploy-vuejs-applications-on-openshift).