### PR TITLE
Header scrolls with page so anchor links don't get hidden

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -14,10 +14,7 @@ const StyledHeader = styled.header`
   background-color: #036;
   border-bottom: 2px solid #fcba19;
   color: white;
-  position: sticky;
-  top: 0;
   width: 100%;
-  z-index: 1;
 
   a {
     margin: 0 25px;


### PR DESCRIPTION
This pull request changes the site header component's styling to force it to scroll with the page. This is to enable anchor links to work as expected, so a link to `page#anchor-link` has the linked heading visible rather than being covered by the header.

While the [BC Design System guidance on headers](https://developer.gov.bc.ca/Design-System/Header-Basic) uses `position: fixed` in its CSS sample, this is problematic for our Gatsby sites using the `gatsby-remark-autolink-headers` plugin for anchor links in Markdown documents. This plugin injects an `<a>` tag with an SVG image inside the `<h*>` tag used for the heading being linked to. While there are [options for customizing the `<a>` tag](https://www.gatsbyjs.com/plugins/gatsby-remark-autolink-headers/#options), there is no option to customize the markup that gets outputted (see [this StackOverflow thread](https://stackoverflow.com/questions/70580228/gatsby-autolink-headers-but-make-the-entire-heading-the-anchor)).

If it is desirable to have both a fixed/sticky header and working anchor tags that appear in view on page load, we should spend time developing a custom plugin for Markdown anchor links to let us have complete control of the markup.

Before this change:
<img width="1840" alt="Sticky header covering heading with anchor tag" src="https://user-images.githubusercontent.com/25143706/167693423-124fcac6-fc5f-4675-931c-dc85d61883da.png">

After this change:
<img width="1840" alt="Heading with anchor tag visible with header out of the viewport" src="https://user-images.githubusercontent.com/25143706/167693594-6633701f-031e-4d82-9ef8-baaa4883618f.png">
