### PR TITLE
App Resiliency Guidelines sort_order and homepage link

### DIFF
--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -14,6 +14,8 @@ audience: developer, technical lead, product owner
 author: Matt Spencer
 
 content_owner: Olena Mitovska
+
+sort_order: 2
 ---
 # Application Resiliency Guidelines
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -136,7 +136,11 @@ const IndexPage = () => (
         <Card>
           <h3>Automation and resiliency</h3>
           <ul>
-            <li>App resiliency guidelines</li>
+            <li>
+              <Link to={"/app-resiliency-guidelines"}>
+                App resiliency guidelines
+              </Link>
+            </li>
             <li>CI/CD Pipeline automation</li>
           </ul>
         </Card>


### PR DESCRIPTION
- Add a `sort_order` field to the frontmatter in the App Resiliency Guidelines file (1c7b96b)
- Add a homepage `<Link>` to the App Resiliency Guidelines page (080d1e3)

<img width="1840" alt="Homepage showing App Resiliency Guidelines page" src="https://user-images.githubusercontent.com/25143706/167739463-c47aa412-9a43-4193-bf17-06b7ee749c3c.png">