### PR TITLE
Update site title and mobile styling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: `Platform Services Documentation`,
+    title: `Private Cloud as a Service Technical Documentation`,
     description: `Documentation for the BC Government's Private Cloud Platform as a Service.`,
     author: `@bcgov`,
     siteUrl: `https://paas.cloud.gov.bc.ca`,
@@ -17,8 +17,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `Platform Developer Docs`,
-        short_name: `Platform Developer Docs`,
+        name: `Private Cloud as a Service Technical Documentation`,
+        short_name: `Private Cloud Tech Docs`,
         start_url: `/`,
         background_color: `white`,
         // This will impact how browsers show your PWA/website

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -28,6 +28,7 @@ const StyledHeader = styled.header`
     &.vertical {
       height: 65px;
       width: 58px;
+      min-width: 58px;
       margin-right: 20px;
     }
   }

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -283,7 +283,7 @@ export default function Navigation() {
                   <ul>
                     <NavListItem
                       id="build-deploy-and-maintain-apps"
-                      title="Build, deploy, and maintain apps"
+                      title="Build, deploy and maintain apps"
                       links={buildDeployAndMaintainApps}
                     />
                     <NavListItem

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -155,6 +155,7 @@ const StyledDiv = styled.div`
     border-right: none;
     border-bottom: 1px solid #b1b4b6;
     box-shadow: 1px 1px 3px rgb(0 0 0 / 10%);
+    width: 100%;
     min-width: 100%;
   }
 

--- a/src/components/search-bar.js
+++ b/src/components/search-bar.js
@@ -28,6 +28,7 @@ const StyledForm = styled.form`
     flex-grow: 1;
     border: 2px solid #606060;
     padding: 5px;
+    width: 100%;
   }
 
   button {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -67,7 +67,7 @@ const IndexPage = () => (
           </ul>
         </Card>
         <Card>
-          <h2>Build, Deploy, and Maintain Apps</h2>
+          <h2>Build, Deploy and Maintain Apps</h2>
           <p>Best practices on the platform.</p>
           <ul>
             <li>Build an application (coming soon)</li>


### PR DESCRIPTION
This pull request updates the site's title and makes CSS adjustments to support the new, longer name.

- Site name changed to "Private Cloud as a Service Technical Documentation" (775c7a6)
- Add `min-width` to vertical SVG logo in header to prevent it from collapsing on small mobile screens (d7aee7c)
- Navigation component is updated to prevent the search form from overflowing on very small mobile screens (iPhone 4 320px wide) (c239d92)
- Remove serial common in label for "Build, Deploy and Maintain Apps" (90ccb0d)

<img width="1840" alt="Homepage on desktop" src="https://user-images.githubusercontent.com/25143706/167943699-a6caaf05-2957-4e0d-b69d-4f22a49f790f.png">
<img width="503" alt="Homepage on iPhone 4" src="https://user-images.githubusercontent.com/25143706/167943757-d78862d1-4c81-4863-b383-6c0fbb0aa882.png">
