### PR TITLE
Add meta description and keyword tags to Markdown pages

### DIFF
--- a/src/pages/{MarkdownRemark.frontmatter__slug}.js
+++ b/src/pages/{MarkdownRemark.frontmatter__slug}.js
@@ -11,7 +11,11 @@ export default function Template({
   const { frontmatter, html } = markdownRemark;
   return (
     <Layout>
-      <Seo title={frontmatter?.title} />
+      <Seo
+        title={frontmatter?.title}
+        description={frontmatter?.description}
+        meta={[{ property: "keywords", content: frontmatter?.keywords }]}
+      />
       <main dangerouslySetInnerHTML={{ __html: html }} />
     </Layout>
   );


### PR DESCRIPTION
This pull request adds `<meta>` tags for descriptions and keywords to generated Markdown pages. Without this, the `description` tag uses the site default, and the keywords from the Markdown frontmatter don't get used at all.

Example output for Artifactory page:

```
<meta name="description" content="Discusses available Artifactory features and management" data-react-helmet="true">
<meta property="keywords" content="Artifactory, images, artifact, best practices, Artifactory management, repositories, projects, service account" data-react-helmet="true">
```