### PR TITLE
Fix nginx try_files to not forward all requests to index

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,7 +26,7 @@ http {
 
     location / {
       root /usr/share/nginx/html;
-      try_files $uri /index.html;
+      try_files $uri $uri/ =404;
     }
   }
 }


### PR DESCRIPTION
As currently written, the included `./nginx.conf` configuration file doesn't let users navigate directly to specific page URLs in production. Requests to `/some-valid-path` are forwarded to `/`. Users are able to navigate to specific pages by first going to `/` and then navigating through the Gatsby SPA router.

With this update, requests for specific paths are forwarded to that path, or the default nginx 404 if they fail. This will make 404s obvious to allow us to handle them properly. In the future, we will build out a meaningful 404 page that is styled to our specification.

Example 404:
<img width="1840" alt="404 path example" src="https://user-images.githubusercontent.com/25143706/168388778-be7fd3d1-ed0e-4b31-96d4-1dc41111ceb1.png">

Example 200 after navigating straight to the desired page:
<img width="1840" alt="Example 200" src="https://user-images.githubusercontent.com/25143706/168388788-6b03e679-5f50-4774-be31-1f4a60f8ffe9.png">
