### PR TITLE
Fix nginx port redirection for deployment on OpenShift

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@ module.exports = {
     author: `@bcgov`,
     siteUrl: `${process.env.GATSBY_SITE_URL}`,
   },
-  trailingSlash: `never`,
+  trailingSlash: `always`,
   plugins: [
     `gatsby-plugin-react-helmet`,
     `gatsby-plugin-react-svg`,

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,6 +19,7 @@ http {
   server {
     listen 8080;
     server_name _;
+    port_in_redirect off;
 
     index index.html;
     error_log  /tmp/error.log;

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -101,7 +101,7 @@ const NavListItem = ({ id, links, title }) => {
           return (
             <li key={`link-${index}`}>
               <Link
-                to={`/${page?.frontmatter?.slug}`}
+                to={`/${page?.frontmatter?.slug}/`}
                 activeClassName={"active"}
               >
                 {page?.frontmatter?.title}


### PR DESCRIPTION
This pull request adjusts `./nginx.conf` to set `port_in_redirect` to `off` (9c5f0c3). In OpenShift, redirects currently have port 8080 in-lined in the URL, breaking redirection and resulting in time-outs. In `./gatsby-config.js`, the option `trailingSlashes` is set to `always` to write paths with trailing slashes (e03ba6d) which [seems to be the most sane option](https://jonsully.net/blog/trailing-slashes-and-gatsby/).

In the Navigation component, `<Link>`s are now built using trailing slashes to match this configuration (9de8dfd). This should minimize the number of 301s and speed the site up.