### PR TITLE
Add gatsby-remark-copy-linked-files plugin for serving static files

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -58,6 +58,7 @@ module.exports = {
       options: {
         plugins: [
           `gatsby-remark-autolink-headers`,
+          `gatsby-remark-copy-linked-files`,
           {
             resolve: `gatsby-remark-images`,
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "gatsby-plugin-styled-components": "^5.12.1",
         "gatsby-plugin-typography": "^4.12.1",
         "gatsby-remark-autolink-headers": "^5.12.1",
+        "gatsby-remark-copy-linked-files": "^5.14.0",
         "gatsby-remark-images": "^6.12.1",
         "gatsby-source-filesystem": "^4.13.0",
         "gatsby-transformer-remark": "^5.12.1",
@@ -10537,6 +10538,27 @@
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/gatsby-remark-copy-linked-files": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-5.14.0.tgz",
+      "integrity": "sha512-qZGAaziKtjNVohW3rWtfVZ4H6/6UonTCTM1du5cIL/VGhgnOQBsBoxgSEpD0gC7oH2TvJAFYh6CHixdjFkIkZQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "cheerio": "^1.0.0-rc.10",
+        "fs-extra": "^10.1.0",
+        "is-relative-url": "^3.0.0",
+        "lodash": "^4.17.21",
+        "path-is-inside": "^1.0.2",
+        "probe-image-size": "^7.2.3",
+        "unist-util-visit": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
+      }
+    },
     "node_modules/gatsby-remark-images": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-6.13.0.tgz",
@@ -15384,6 +15406,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -28853,6 +28880,21 @@
         "unist-util-visit": "^2.0.3"
       }
     },
+    "gatsby-remark-copy-linked-files": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-5.14.0.tgz",
+      "integrity": "sha512-qZGAaziKtjNVohW3rWtfVZ4H6/6UonTCTM1du5cIL/VGhgnOQBsBoxgSEpD0gC7oH2TvJAFYh6CHixdjFkIkZQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "cheerio": "^1.0.0-rc.10",
+        "fs-extra": "^10.1.0",
+        "is-relative-url": "^3.0.0",
+        "lodash": "^4.17.21",
+        "path-is-inside": "^1.0.2",
+        "probe-image-size": "^7.2.3",
+        "unist-util-visit": "^2.0.3"
+      }
+    },
     "gatsby-remark-images": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-6.13.0.tgz",
@@ -32368,6 +32410,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gatsby-plugin-styled-components": "^5.12.1",
     "gatsby-plugin-typography": "^4.12.1",
     "gatsby-remark-autolink-headers": "^5.12.1",
+    "gatsby-remark-copy-linked-files": "^5.14.0",
     "gatsby-remark-images": "^6.12.1",
     "gatsby-source-filesystem": "^4.13.0",
     "gatsby-transformer-remark": "^5.12.1",


### PR DESCRIPTION
This pull request adds the `gatsby-remark-copy-linked-files` plugin and uses it in `./gatsby-config` to serve static files linked from Markdown documents (36ef313). As an example, see `./src/docs/app-monitoring/sysdig-monitor-setup-team.md` which includes a link to a sample YAML file. Files like this get served from `/<file_hash>/<file_name>.<file_extension>`:

<img width="1840" alt="Sysdig Monitor Setup Team page with link to a YAML file" src="https://user-images.githubusercontent.com/25143706/168915592-8068db8f-c50b-4e02-a82f-cf7190701676.png">
<img width="1840" alt="YAML file displayed in browser" src="https://user-images.githubusercontent.com/25143706/168915612-6cc423dc-865c-45b7-b783-aaff74bf50ce.png">

This supports the addition of the YAML file in #45.