### PR TITLE
Homepage and Provisioning content updates

### DIFF
--- a/src/docs/openshift-projects-and-access/provision-new-openshift-project.md
+++ b/src/docs/openshift-projects-and-access/provision-new-openshift-project.md
@@ -20,27 +20,21 @@ sort_order: 1
 
 # Provision a new OpenShift project
 
-On the OpenShift platform, different teams organize their work in isolated projects. Before you can work on the platform, you need to submit a project provisioning request to have a set of projects provisioned by the OCIO Enterprise DevOps branch.
+On the OpenShift platform, different teams organize their work in isolated projects. Before you can work on the platform, you need to submit a project provisioning request to have a project set provisioned for you on the Private Cloud PaaS.
 
 Each new request must be reviewed and approved, including requests for additional projects from teams that already have one or more projects on the platform.
 
-## Submit a project provisioning request
-
-If you meet the criteria, book an onboarding meeting with the BC Gov Private Cloud PaaS product director to confirm your project's suitability, by contacting the Platform Services team at [PlatformServicesTeam@gov.bc.ca](mailto:PlatformServicesTeam@gov.bc.ca). After the alignment meeting, your product owner or your ministry's DevOps chapter lead can submit a project provisioning request through the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing). Once your request is approved, the project is created and the requestor is notified when provisioning is complete.
-
-**Note**: The onboarding meeting with the platform product director is a prerequisite to having a project provisioning request approved.
-
-**For Attorney General (AG) teams only**: Contact Ryan Loiselle at Ryan.Loiselle@gov.bc.ca to submit the request for you.
-
-OpenShift namespaces are auto-generated at provisioning in the form of `<generated alphanumeric string>-<environment>`. We call them `project license plates`.
-
-While you wait for the alignment meeting, check out our [OnBoarding Guide for BC Gov DevOps Platform](https://docs.google.com/presentation/d/1UcT0b2YTPki_o0et9ZCLKv8vF19eYakJQitU85TAeD4/edit?usp=sharing) to learn about the available services and the easier way to integrate with the platform community.
+Read more about project provisioning and the prerequisites in [this article](https://platform-services-dev.apps.silver.devops.gov.bc.ca/our-products-in-the-private-cloud-paas/project-registry/) or submit the project provisioning request through [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing).
 
 ---
+
 Related links:
-* [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing)
-* [OnBoarding Guide for BC Gov DevOps Platform](https://docs.google.com/presentation/d/1UcT0b2YTPki_o0et9ZCLKv8vF19eYakJQitU85TAeD4/edit?usp=sharing)
+
+- [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing)
+- [OnBoarding Guide for BC Gov DevOps Platform](https://docs.google.com/presentation/d/1UcT0b2YTPki_o0et9ZCLKv8vF19eYakJQitU85TAeD4/edit?usp=sharing)
 
 Rewrite sources:
-* https://developer.gov.bc.ca/Getting-Started-on-the-DevOps-Platform/How-to-Request-a-New-OpenShift-Project
+
+- https://developer.gov.bc.ca/Getting-Started-on-the-DevOps-Platform/How-to-Request-a-New-OpenShift-Project
+
 ---

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -80,13 +80,15 @@ const IndexPage = () => (
       <h2>Training and Learning</h2>
       <Grid className="col-3">
         <Card>
-          <h3>OpenShift 101</h3>
+          <h3>Free OpenShift Training</h3>
           <p>
-            This training covers several technical topics, and provides an
-            overview of the build and deploy processes for cloud-native
-            applications on OpenShift.
+            Read about{" "}
+            <a href="https://platform-services-dev.apps.silver.devops.gov.bc.ca/support-and-community/training-from-the-private-cloud-team/">
+              the free training
+            </a>{" "}
+            that is offered on the Platform and get access to other learning
+            resources.
           </p>
-          <p>Register for OpenShift 101. (coming soon)</p>
         </Card>
         <Card>
           <h3>Rocket.Chat</h3>


### PR DESCRIPTION
1. The homepage is updated to update the "OpenShift 101" (ebded08).

Before:
<img width="1840" alt="Homepage screenshot before" src="https://user-images.githubusercontent.com/25143706/168924253-d41ca78e-4b97-4eee-ab22-3b009ffc7ec5.png">

After:
<img width="1840" alt="Homepage screenshot after" src="https://user-images.githubusercontent.com/25143706/168924264-b1a5d6c1-7c14-4365-b0fc-0d83e78530cc.png">

2. The "Provision a new OpenShift Project" page is updated to link to the equivalent document on the WordPress site, and to remove the now-redundant page content (feabd41).

Before:
<img width="1840" alt="Provisioning page before" src="https://user-images.githubusercontent.com/25143706/168924416-b9d34e35-77ef-4640-93bf-e91cd70c17ca.png">

After:
<img width="1840" alt="Provisioning page after" src="https://user-images.githubusercontent.com/25143706/168924436-e315c741-f17d-46ab-983a-ab2a77f64a75.png">
