### PR TITLE
Handle links between Markdown documents

### DIFF
--- a/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
+++ b/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
@@ -121,8 +121,8 @@ It's recommended to create alerts from an application monitoring metrics, which 
 
 ---
 Related links:
-- [Set up advanced functions in Sysdig Monitor](./sysdig-monitor-set-up-advanced-functions.md)
-- [Set up a team in Sysdig Monitor](./sysdig-monitor-setup-team.md)
+- [Set up advanced functions in Sysdig Monitor](/sysdig-monitor-set-up-advanced-functions/)
+- [Set up a team in Sysdig Monitor](/sysdig-monitor-setup-team/)
 
 Related resources:
 - [Sysdig Monitor](https://docs.sysdig.com/en/sysdig-monitor.html)

--- a/src/docs/app-monitoring/sysdig-monitor-onboarding.md
+++ b/src/docs/app-monitoring/sysdig-monitor-onboarding.md
@@ -33,9 +33,9 @@ tags:
 
 ### Here are the documents for you to follow through:
 
-1. [Set up a team in Sysdig Monitor](./sysdig-monitor-setup-team.md)
-1. [Create alerts for metrics](./sysdig-monitor-create-alert-channels.md)
-1. [Advanced Usage in Sysdig Monitor](./sysdig-monitor-set-up-advanced-functions.md)
+1. [Set up a team in Sysdig Monitor](/sysdig-monitor-setup-team/)
+1. [Create alerts for metrics](/sysdig-monitor-create-alert-channels/)
+1. [Advanced Usage in Sysdig Monitor](/sysdig-monitor-set-up-advanced-functions/)
 
 If you have any questions about Sysdig or application monitoring, please contact the Platform Services team on the [#devops-sysdig Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
 
@@ -43,7 +43,7 @@ If you have any questions about Sysdig or application monitoring, please contact
 Related links:
 - [BCDevOps Sysdig Monitor Service](https://app.sysdigcloud.com/api/oauth/openid/bcdevops)
 - [Sysdig Monitor](https://sysdig.com/products/monitor/)
-- [OpenShift project resource quotas](/docs/automation-and-resiliency/openshift-project-resource-quotas.md)
+- [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 - [Sysdig API](https://docs.sysdig.com/en/docs/developer-tools/sysdig-rest-api-conventions/)
 - [Monitoring with Sysdig](New page on Wordpress site)
 - [Sydig User Profile](https://app.sysdigcloud.com/#/settings/user)

--- a/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
+++ b/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
@@ -66,8 +66,8 @@ To enable Promscrape to find your application metrics, do the following:
 
 ---
 Related links:
-- [Set up a team in Sysdig Monitor](./setup-team-sysdig-monitor.md)
-- [Create alert channels in Sysdig Monitor](./create-alert-channels-sysdig-monitor.md)
+- [Set up a team in Sysdig Monitor](/sysdig-monitor-setup-team/)
+- [Create alert channels in Sysdig Monitor](/sysdig-monitor-create-alert-channels/)
 - [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
 - [Migrate Using Default Configuration](https://docs.sysdig.com/en/docs/sysdig-monitor/integrations-for-sysdig-monitor/configure-monitoring-integrations/migrating-from-promscrape-v1-to-v2/#migrate-using-default-configuration)
 

--- a/src/docs/app-monitoring/sysdig-monitor-setup-team.md
+++ b/src/docs/app-monitoring/sysdig-monitor-setup-team.md
@@ -22,7 +22,7 @@ sort_order: 2
 
 [Sysdig Monitor](https://sysdig.com/products/monitor/) provides system-level monitoring of Kubernetes hosts and the ability to create custom dashboards, alerts and operational-level captures to diagnose application or platform-level issues.
 
-The Sysdig Teams Operator runs in the cluster and enables a team to create and manage access to a dedicated Sysdig Team account for BC Gov Private Cloud PaaS OpenShift platform users. The team is scoped to the OpenShift namespaces that belong to the team. Sysdig also provides a default dashboard to identify system [resources, limits and actual usage](/docs/automation-and-resiliency/openshift-project-resource-quotas.md).
+The Sysdig Teams Operator runs in the cluster and enables a team to create and manage access to a dedicated Sysdig Team account for BC Gov Private Cloud PaaS OpenShift platform users. The team is scoped to the OpenShift namespaces that belong to the team. Sysdig also provides a default dashboard to identify system [resources, limits and actual usage](/openshift-project-resource-quotas/).
 
 For more information on Sysdig Monitor, see [Monitoring with Sysdig](New page on Wordpress site).
 
@@ -172,10 +172,10 @@ You should see the following dashboard templates from your Sysdig team:
 ---
 Related links:
 - [BCDevOps Sysdig Monitor Service](https://app.sysdigcloud.com/api/oauth/openid/bcdevops)
-- [Set up advanced functions in Sysdig Monitor](./sysdig-monitor-set-up-advanced-functions.md)
-- [Create alert channels in Sysdig Monitor](./sysdig-monitor-create-alert-channels.md)
+- [Set up advanced functions in Sysdig Monitor](/sysdig-monitor-set-up-advanced-functions/)
+- [Create alert channels in Sysdig Monitor](/sysdig-monitor-create-alert-channels/)
 - [Sysdig Monitor](https://sysdig.com/products/monitor/)
-- [OpenShift project resource quotas](/docs/automation-and-resiliency/openshift-project-resource-quotas.md)
+- [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 - [Sysdig API](https://docs.sysdig.com/en/docs/developer-tools/sysdig-rest-api-conventions/)
 - [Monitoring with Sysdig](New page on Wordpress site)
 - [Sydig User Profile](https://app.sysdigcloud.com/#/settings/user)

--- a/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
+++ b/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
@@ -31,7 +31,7 @@ New project sets provisioned in **all clusters** of the BC Gov Private Cloud Paa
 - [Memory quotas](#memory)
 - [Storage quotas](#storage)
 
-If the default allocations aren't sufficient for your application, [you can ask for a quota increase](./request-quota-increase-for-openshift-project-set.md). You'll need a Sysdig dashboard that shows that your application needs more of a specific resource type (CPU, RAM or storage) in a specific namespace. Provide this proof to the Platform Services team before they can approve a quota increase that you submit in the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing).
+If the default allocations aren't sufficient for your application, [you can ask for a quota increase](/request-quota-increase-for-openshift-project-set/). You'll need a Sysdig dashboard that shows that your application needs more of a specific resource type (CPU, RAM or storage) in a specific namespace. Provide this proof to the Platform Services team before they can approve a quota increase that you submit in the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing).
 
 ## CPU quotas<a name="cpu"></a>
 

--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -44,7 +44,7 @@ Before you ask for a quota increase, the Platform Services team wants you to mon
 
 If you determine that your application needs a quota increase, you can have a product owner or technical lead on your project make the request on the **Project Edit** page on the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing). The Platform Services team must approve the request before it's processed.
 
-If you need more resources for CPU, RAM or storage in any of the four namespaces (`dev`, `test`, `tool` or `prod`), you must submit a standard quota increase request through the Platform Project Registry. For more information on quotas, see [OpenShift project resource quotas](./openshift-project-resource-quotas.md).
+If you need more resources for CPU, RAM or storage in any of the four namespaces (`dev`, `test`, `tool` or `prod`), you must submit a standard quota increase request through the Platform Project Registry. For more information on quotas, see [OpenShift project resource quotas](/openshift-project-resource-quotas/).
 
 ## Collect application metrics<a name="collect-metrics"></a>
 
@@ -91,7 +91,7 @@ Related links:
 * [Get Started with Sysdig Monitoring](https://developer.gov.bc.ca/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring)
 * [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
 * [Openshift 4 Project Registry](https://registry.developer.gov.bc.ca/public-landing)
-* [OpenShift project resource quotas](./openshift-project-resource-quotas.md)
+* [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 * [S3 Object Storage Service](https://github.com/BCDevOps/OpenShift4-Migration/issues/59)
 
 Rewrite sources:

--- a/src/docs/build-deploy-and-maintain-apps/image-artifact-management-with-artifactory.md
+++ b/src/docs/build-deploy-and-maintain-apps/image-artifact-management-with-artifactory.md
@@ -39,7 +39,7 @@ The Platform Services team uses Artifactory to provide the following services:
 
 * Remote repositories serve as caches/proxies for all major public artifact repositories/registries and several private repositories/registries where BC Government owns licensed access. These repositories cache artifacts that are pulled through them, reducing build time and network traffic. The list of remote repositories include DockerHub, NPM, PyPi, RedHat's private image registry and more.
 
-* Artifactory Projects are spaces of quota-limited storage where teams have full control. This lets teams create their own private repositories in Artifactory where they can push and pull their own artifacts of any type. It also allows teams to control access to these repositories, similar to the way teams control access to their own OpenShift namespaces. For more information on requesting an Artifactory Project, see [Setup an Artifactory project and repository](./setup-artifactory-project-repository.md).
+* Artifactory Projects are spaces of quota-limited storage where teams have full control. This lets teams create their own private repositories in Artifactory where they can push and pull their own artifacts of any type. It also allows teams to control access to these repositories, similar to the way teams control access to their own OpenShift namespaces. For more information on requesting an Artifactory Project, see [Setup an Artifactory project and repository](/setup-artifactory-project-repository/).
 
 * Xray is an add-on service to Artifactory that provides security scanning for all objects in Artifactory. This includes any objects that have been cached in Artifactory through the remote repositories and all artifacts pushed to any private repositories created by individual teams. Teams are able to create and review security reports on artifacts in their private repositories.
 
@@ -70,7 +70,7 @@ You can use a local private repository to push your own artifacts and images, wi
 
 * You can use the same pull secrets you use to access the remote repositories.
 
-You need to set up an Artifactory project before you can get a local private repository. For more information, see [Setup an Artifactory project and repository](./setup-artifactory-project-repository.md).
+You need to set up an Artifactory project before you can get a local private repository. For more information, see [Setup an Artifactory project and repository](/setup-artifactory-project-repository/).
 
 ## Xray artifact scanning<a name="xray"></a>
 The Xray tool scans all artifacts for security issues and lets you know about potential issues. This gives you an opportunity to deal with issues before they become a problem. The benefits include the following:
@@ -104,7 +104,7 @@ Other operations require turning Artifactory to read-only mode. In read-only mod
 
 ## Set up Artifactory<a name="setup"></a>
 
-To get started using Artifactory, see [Setup an Artifactory service account](./setup-artifactory-service-account.md).
+To get started using Artifactory, see [Setup an Artifactory service account](/setup-artifactory-service-account/).
 
 ---
 Related links:
@@ -114,8 +114,8 @@ Related links:
 * [#devops-artifactory](https://chat.pathfinder.gov.bc.ca/channel/devops-artifactory)
 * [#devops-sos](https://chat.pathfinder.gov.bc.ca/channel/devops-sos)
 * [#devops-alerts](https://chat.pathfinder.gov.bc.ca/channel/devops-alerts)
-* [Setup an Artifactory service account](./setup-artifactory-service-account.md)
-* [Setup an Artifactory project and repository](./setup-artifactory-project-repository.md)
+* [Setup an Artifactory service account](/setup-artifactory-service-account/)
+* [Setup an Artifactory project and repository](/setup-artifactory-project-repository/)
 
 Rewrite sources:
 * https://github.com/BCDevOps/openshift-wiki/blob/master/docs/Artifactory/ServiceDefinition.md

--- a/src/docs/build-deploy-and-maintain-apps/push-pull-artifacts-artifactory.md
+++ b/src/docs/build-deploy-and-maintain-apps/push-pull-artifacts-artifactory.md
@@ -18,7 +18,7 @@ content_owner: Cailey Jones
 sort_order: 7
 ---
 # Push and pull artifacts in Artifactory
-After you've [set up your Artifactory service account](./setup-artifactory-service-account-repository-project.md), you can pull artifacts from the platform's caching repositories. If you wish to push to Artifactory, you will need an [Artifactory project and private repository first](./setup-artifactory-service-account-repository-project.md). After your set up your private repository, follow these instructions to pull from them.
+After you've [set up your Artifactory service account](/setup-artifactory-service-account/), you can pull artifacts from the platform's caching repositories. If you wish to push to Artifactory, you will need an [Artifactory project and private repository first](/setup-artifactory-project-repository/). After your set up your private repository, follow these instructions to pull from them.
 
 ## On this page
 - [Pull Docker images from Artifactory](#pull-docker)
@@ -188,7 +188,8 @@ If your team uses a specific package type not shown here, consider creating a pu
 
 ---
 Related links:
-* [Setup an Artifactory service account, repository, and project](./setup-artifactory-service-account-repository-project.md)
+* [Set up an Artifactory service account](/setup-artifactory-service-account/)
+* [Set up an Artifactory project and repository](/setup-artifactory-project-repository/)
 * [NPM repository](https://registry.npmjs.org)
 * [repo-mountie assemble file](https://github.com/bcgov/repomountie/blob/master/.s2i/bin/assemble)
 

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
@@ -123,7 +123,7 @@ Related links:
 * [Archeobot](bcgov/platform-services-archeobot)
 * [Artifactory](https://artifacts.developer.gov.bc.ca)
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
-* [Setup an Artifactory service account](./setup-artifactory-service-account.md)
+* [Setup an Artifactory service account](/setup-artifactory-service-account/)
 
 Rewrite sources:
 * https://github.com/BCDevOps/openshift-wiki/blob/master/docs/Artifactory/ServiceDefinition.md

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
@@ -94,7 +94,7 @@ Related links:
 * [Archeobot](bcgov/platform-services-archeobot)
 * [Artifactory](https://artifacts.developer.gov.bc.ca)
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
-* [Setup an Artifactory project and repository](./setup-artifactory-project-repository.md)
+* [Setup an Artifactory project and repository](/setup-artifactory-project-repository/)
 
 Rewrite sources:
 * https://github.com/BCDevOps/openshift-wiki/blob/master/docs/Artifactory/ServiceDefinition.md

--- a/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
+++ b/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
@@ -37,7 +37,7 @@ If you want to grant a new user access to OpenShift they must have the following
 - A GitHub account (ideally with a complete profile)
 - Two-factor authentication enabled on their GitHub account
 
-Additionally, the namespace where you are adding the new user must have already have been provisioned through [the new project provisioning process](./provision-new-openshift-project.md) and must have one or more administrative users.
+Additionally, the namespace where you are adding the new user must have already have been provisioned through [the new project provisioning process](/provision-new-openshift-project/) and must have one or more administrative users.
 
 ## Add users<a name="add-users"></a>
 
@@ -83,8 +83,8 @@ Follow these best practices when you grant namespace access to a user:
 
 ---
 Related links:
-* [BC Government organizations in Github](./bc-government-organizations-in-github.md)
-* [Provision a new project set](./provision-new-openshift-project.md)
+* [BC Government organizations in Github](/bc-government-organizations-in-github/)
+* [Provision a new project set](/provision-new-openshift-project/)
 * [Using Just Ask! to gain access into the BCGov or BCDevops Github Organizations](https://www.youtube.com/watch?v=IvdPyx2-qm0)
 * [Add someone to the BC Government GitHub Org](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [Using RBAC to define and apply permissions](https://docs.openshift.com/container-platform/4.9/authentication/using-rbac.html)

--- a/src/docs/platform-architecture-reference/platform-storage.md
+++ b/src/docs/platform-architecture-reference/platform-storage.md
@@ -39,7 +39,7 @@ We have access to the following storage services for the OpenShift platform.
 
 ### OpenShift Persistent Volumes (NetApp)
 
-All NetApp storage classes support resizing (bigger only). You can start with a small volume and edit your Persisent Volume Claim (PVC) to have a larger `.spec.resources.requests.storage` later if you need more. You may need to restart the pods attached to let the resize trigger on re-mount. **Note: the storage increase is capped by the storage quota assigned to the namespace. For the current resource quota sizes, see [OpenShift project resource quotas](/docs/automation-and-resiliency/openshift-project-resource-quotas.md).
+All NetApp storage classes support resizing (bigger only). You can start with a small volume and edit your Persisent Volume Claim (PVC) to have a larger `.spec.resources.requests.storage` later if you need more. You may need to restart the pods attached to let the resize trigger on re-mount. **Note: the storage increase is capped by the storage quota assigned to the namespace. For the current resource quota sizes, see [OpenShift project resource quotas](/openshift-project-resource-quotas/).
 
 * **NetApp File**: `netapp-file-standard` is the default storage class for the platform and the type of storage you get if you don't specify a specific `storageClass`.
 
@@ -128,7 +128,7 @@ The speed of each storage solution depends on your workload. ElasticSearch speci
 
 ---
 Related links:
-* [OpenShift project resource quotas](/docs/automation-and-resiliency/openshift-project-resource-quotas.md)
+* [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 * [Backup and Restore](https://developer.gov.bc.ca/OCP4-Backup-and-Restore)
 * [Red Hat documentation](https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_and_managing_openshift_container_storage_using_red_hat_openstack_platform/volume-snapshots_osp)
 * [BCDevOps/Backup-Container](https://github.com/bcdevops/backup-container)

--- a/src/docs/training-and-learning/training-external-resources.md
+++ b/src/docs/training-and-learning/training-external-resources.md
@@ -19,7 +19,7 @@ sort_order: 3
 ---
 # External training resources 
 
-The resources below are from sources outside of the B.C. government. They provide additional context and support to go along with your [training from the Platform Services team](./training-external-resources.md).   
+The resources below are from sources outside of the B.C. government. They provide additional context and support to go along with your [training from the Platform Services team](/training-from-the-platform-services-team/).
 
 ## Websites:
 
@@ -52,5 +52,5 @@ The resources below are from sources outside of the B.C. government. They provid
 
 ---
 Related links:
-- [Training from the Platform Services team](./training-external-resources.md)
+- [Training from the Platform Services team](/training-from-the-platform-services-team/)
 ---

--- a/src/docs/training-and-learning/training-from-the-platform-services-team.md
+++ b/src/docs/training-and-learning/training-from-the-platform-services-team.md
@@ -50,5 +50,5 @@ We’re developing an OpenShift 201 course to cover more advanced skills than th
 
 ---
 Related links:
-- [External training resources](./training-external-resources.md)
+- [External training resources](/training-external-resources/)
 ---

--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -66,9 +66,9 @@ Your product team can only have a **permanent**, private repository in `bcgov-c`
 
 Ministry-specific **private** organizations must be linked to the B.C. government's Enterprise account (user licenses are required for the members of these organizations).
 
-These organizations permanently store teams' private repositories with closed-sourced code that can't be transitioned to a public repository within 12 months. For more information on creating a private organization linked to the GitHub enterprise account, see [GitHub Enterprise user licences in the B.C. government](./github-enterprise-user-licenses-bc-government.md).
+These organizations permanently store teams' private repositories with closed-sourced code that can't be transitioned to a public repository within 12 months. For more information on creating a private organization linked to the GitHub enterprise account, see [GitHub Enterprise user licences in the B.C. government](/github-enterprise-user-licenses-bc-government/).
 * Product teams that need a permanent location for their closed-source code should use this repository.
-* Each ministry team must purchase their own [user licenses](./github-enterprise-user-licenses-bc-government.md) to use the organization.
+* Each ministry team must purchase their own [user licenses](/github-enterprise-user-licenses-bc-government/) to use the organization.
 * Only ministry GitHub administrators can create repositories in this organization. Consult with your ministry's Information Management Branch (IMB) to get in touch with the GitHub administrators.
 
 ![Diagram of the BC Goverment GitHub organizations](../../images/github-organization-chart.png)
@@ -83,9 +83,9 @@ Related links:
 * [bcgov](https://github.com/bcgov)
 * [Digital Principles for BC Goverment](https://digital.gov.bc.ca/resources/digital-principles)
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
-* [GitHub Enterprise user licences in the BC government](./github-enterprise-user-licenses-bc-government.md)
-* [Remove a user's BCGov GitHub access](./remove-user-bcgov-github-access.md)
-* [Request BCGov GitHub access or repository creation](./request-bcgov-github-access-repository-creation.md)
+* [GitHub Enterprise user licences in the BC government](/github-enterprise-user-licenses-bc-government/)
+* [Remove a user's BCGov GitHub access](/remove-user-bcgov-github-access/)
+* [Request BCGov GitHub access or repository creation](/request-bcgov-github-access-repository-creation/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/docs/use-github-in-bcgov/evaluate-open-source-content.md
+++ b/src/docs/use-github-in-bcgov/evaluate-open-source-content.md
@@ -22,7 +22,7 @@ sort_order: 5
 
 Use the following guidelines to make sure that you are able to use existing, open-source content on GitHub.
 
-For more information on approval requirements, see [Start working in the BC Gov GitHub organization](./start-working-in-bcgov-github-organization.md).
+For more information on approval requirements, see [Start working in the BC Gov GitHub organization](/start-working-in-bcgov-github-organization/).
 
 ## On this page
 - [Privacy](#privacy)
@@ -49,7 +49,7 @@ Make sure to meet the following requirements:
 - Content is created solely by B.C. government employees.
 - Content is fully owned by the B.C. government and doesn't contain any third-party content. Collect copies of any contracts related to the content for review with the [Intellectual Property Program (IPP)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program).
 - Content has no terms of use or exclusive licences that prohibit the Province from licensing the content on GitHub. Collect information concerning any terms of use or licences related to the content for review with the IPP.
-- You have [authority to license the content](./license-your-github-repository.md).
+- You have [authority to license the content](/license-your-github-repository/).
 
 Ministries  **must**  contact the IPP to assist in this assessment. Any legal review or legal advice is provided by the Legal Services Branch.
 
@@ -67,9 +67,9 @@ Make sure that the material has been labelled **Public**, using the [Information
 
 ---
 Related links:
-- [Start working in the BCGov GitHub organization](./start-working-in-bcgov-github-organization.md)
+- [Start working in the BCGov GitHub organization](/start-working-in-bcgov-github-organization/)
 - [Intellectual Property Program (IPP)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program)
-- [License your GitHub repository](./license-your-github-repository.md)
+- [License your GitHub repository](/license-your-github-repository/)
 - [Ministry Information Security Officer (MISO)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/information-security-policy-and-guidelines/role-of-miso)
 - [Information Security Classification Framework](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification)
 

--- a/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
+++ b/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
@@ -22,7 +22,7 @@ sort_order: 4
 
 All code by B.C. government teams should be open source by default. If you have closed-source code and still want to use GitHub, you can work temporarily in a private repository under the GitHub Enterprise licence.
 
-For more information on our GitHub organizations and their uses, see [B.C. government organizations in Github](./bc-government-organizations-in-github.md).
+For more information on our GitHub organizations and their uses, see [B.C. government organizations in GitHub](/bc-government-organizations-in-github/).
 
 ## On this page
 - [Benefits of a GitHub Enterprise user licence](#benefits)
@@ -74,7 +74,7 @@ Software Central Management handles your purchase order, with billing back to yo
 
 ---
 Related links:
-* [BC Government Organizations in Github](./bc-government-organizations-in-github.md)
+* [BC Government Organizations in GitHub](/bc-government-organizations-in-github/)
 * [Pricing](https://github.com/pricing)
 
 Rewrite sources:

--- a/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
+++ b/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
@@ -39,8 +39,8 @@ GitHub User Access Removal Request:
 ---
 Related links:
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
-* [BC Government organizations in Github](./bc-government-organizations-in-github.md)
-* [Request BCGov GitHub access or repository creation](./request-bcgov-github-access-repository-creation.md)
+* [BC Government organizations in GitHub](/bc-government-organizations-in-github/)
+* [Request BCGov GitHub access or repository creation](/request-bcgov-github-access-repository-creation/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/docs/use-github-in-bcgov/request-bcgov-github-access-repository-creation.md
+++ b/src/docs/use-github-in-bcgov/request-bcgov-github-access-repository-creation.md
@@ -111,9 +111,9 @@ Related links:
 * [Digital Principles for BC Goverment](https://digital.gov.bc.ca/resources/digital-principles)
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [DevOps-Request](https://github.com/BCDevOps/devops-requests/issues/new?assignees=caggles%2C+ShellyXueHan%2C+mitovskaol%2C+patricksimonian&labels=github-repo%2C+pending&template=github_repo_request.md&title=)
-* [GitHub Enterprise user licences in the BC government](./github-enterprise-user-licenses-bc-government.md)
-* [BC Government organizations in Github](./bc-government-organizations-in-github.md)
-* [Remove a user's BCGov GitHub access](./remove-user-bcgov-github-access.md)
+* [GitHub Enterprise user licences in the BC government](/github-enterprise-user-licenses-bc-government/)
+* [BC Government organizations in GitHub](/bc-government-organizations-in-github/)
+* [Remove a user's BCGov GitHub access](/remove-user-bcgov-github-access/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/docs/use-github-in-bcgov/required-pages-for-github-repository.md
+++ b/src/docs/use-github-in-bcgov/required-pages-for-github-repository.md
@@ -31,7 +31,7 @@ When you create a repository in the `bcgov` organization, add the following mark
 - [Contribution guidelines](#contribution)
 
 ## Licence<a name="licence"></a>
-Choose a licence and place a licence file in your repository before you do anything else. For important information on licences, see [License your project](./license-your-project.md).
+Choose a licence and place a licence file in your repository before you do anything else. For important information on licences, see [License your GitHub repository](/license-your-github-repository/).
 
 Depending on the licence you choose, add boilerplate text for the applicable licence to your README file.
 
@@ -43,7 +43,7 @@ For more information, see [About READMEs](https://docs.github.com/en/repositorie
 Make sure to include the following:
 - A brief description of your project.
 - An overview on how to contribute to the repository with a link to your contribution guidelines.
-- Depending on your licence, boilerplate text for the applicable licence. For more information, see [License your GitHub repository](./license-your-github-repository.md).
+- Depending on your licence, boilerplate text for the applicable licence. For more information, see [License your GitHub repository](/license-your-github-repository/).
 - A link to your code of conduct file.
 
 ## Code of conduct<a name="code-of-conduct"></a>
@@ -61,7 +61,7 @@ Make sure you're clear on the licence that applies to your repository and provid
 ---
 Related links:
 * [About READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
-* [License your GitHub repository](./license-your-github-repository.md)
+* [License your GitHub repository](/license-your-github-repository/)
 * [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)
 * [Healthy contributions](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions)
 * [Using pull requests](https://help.github.com/articles/using-pull-requests/)

--- a/src/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
+++ b/src/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
@@ -20,7 +20,7 @@ sort_order: 8
 
 # Start working in the BC Gov GitHub organization
 
-If you plan to share code developed by or for the B.C. government, [evaluate the content](./evaluate-open-source-content.md) and get approval from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
+If you plan to share code developed by or for the B.C. government, [evaluate the content](/evaluate-open-source-content/) and get approval from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
 
 ## On this page
 - [Post existing code or projects](#post-existing)
@@ -28,7 +28,7 @@ If you plan to share code developed by or for the B.C. government, [evaluate the
 - [Contribute to outside code or projects](#contribute)
 
 The B.C. government follows the Open Development Standard, which outlines the following:
-* [Minimum content requirements](./required-pages-for-github-repository.md): README, contributing file, code of conduct and license
+* [Minimum content requirements](/required-pages-for-github-repository/): README, contributing file, code of conduct and license
 * Roles and responsibilities
 * Basic mechanics of working in GitHub
 
@@ -44,7 +44,7 @@ Projects like this follow two basic approaches, but can vary.
 
 In both cases, the basic steps to release the code are similar, while the implications for project management and resourcing are not. Key requirements in these scenarios include the following:
 
-- Confirm your [authority to license](./license-your-github-repository.md)
+- Confirm your [authority to license](/license-your-github-repository/)
 
 	Choose an open-source license and consult with the Intellectual Property Program (IPP) to make sure government has the right to release the code.
 
@@ -64,9 +64,9 @@ If you are intending to maintain an active project, make sure to establish the a
 
 These are projects that you want to manage as an open-source, collaborative project.
 
-- Choose an open-source licence and confirm your [authority to license](./license-your-github-repository.md)
+- Choose an open-source licence and confirm your [authority to license](/license-your-github-repository/)
 - Determine how contributions are made and managed and include this information in the contributor file in the repository.
-- [Create the minimum required content](./required-pages-for-github-repository.md).
+- [Create the minimum required content](/required-pages-for-github-repository/).
 - Add a [Contributor Code of Conduct](http://contributor-covenant.org/) to your repository. This document lets people know that all are welcome to contribute, and that all who contribute pledge to make participation in the project a harassment-free experience for everyone. Include a code of conduct and provide a contact method (in the placeholder) so that people know how to report violations. Introduce the code of conduct in your `readme.md`.
 
 ## Contribute to outside code or projects<a name="contribute"></a>
@@ -80,15 +80,15 @@ There may be circumstances where it's useful and appropriate for employees to co
 
 	If the project uses a reciprocal or "copyleft" license, such as GPL or Mozilla, make sure you understand the requirements for publishing any modifications you make to the code.
 
-- Confirm your [authority to license](./license-your-github-repository.md)
+- Confirm your [authority to license](/license-your-github-repository/)
 
 Employees can also contribute to non-B.C. government owned intellectual property rights outside their professional roles by using their personal email linked to their GitHub account.
 
 ---
 Related links:
-* [evaluate the content](./evaluate-open-source-content.md)
-* [Required pages for a GitHub repository](./required-pages-for-github-repository.md)
-* [License your GitHub repository](./license-your-github-repository.md)
+* [Evaluate the content](/evaluate-open-source-content/)
+* [Required pages for a GitHub repository](/required-pages-for-github-repository/)
+* [License your GitHub repository](/license-your-github-repository/)
 
 Rewrite sources:
 * https://developer.gov.bc.ca/Code-Management/Approaches-to-CollaboratingContributing

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -165,6 +165,8 @@ Track the metadata in the fields of each page based on these descriptions:
 
 - **content_owner**: The SME of the page. They are responsible for the factual accuracy of the content.
 
+- **sort_order**: Determines the order of the link to the page within the navigation menu.
+
 ### Keywords, tags, and taxonomy
 
 It's important to track relevant keywords for each page and to refine them as the content becomes clearer. Eventually, the team uses a taxonomy to help pages get found when users search for them. But there are distinct differences, as shown in [the quotes from this blog below](https://contentstrategyinc.com/mays-vancouver-iacs-meetup-understanding-taxonomies/):

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -83,6 +83,8 @@ The resources below have more information. They are concerned largely with forms
 
 Make sure that the link to an external page is descriptive. The user should know (or have a good idea) where the link is going to take them before they click it.
 
+When linking from one Markdown page in the `./src/docs/` folder to another, write the link in the form `/<slug of the target page>`. While these links won't work when viewing the page on GitHub, they will work on the Gatsby site.
+
 ### FAQs
 [Don't write FAQs](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/faqs) or format sections as a question and answer. Just tell the reader what they need to know.
 
@@ -149,7 +151,7 @@ Track the metadata in the fields of each page based on these descriptions:
 
 - **title**: The title of the page. The _best_ title you can create.
 
-- **slug**: This appends the URL, so it shows the path of the page on the Gatsby site.
+- **slug**: This appends the URL, so it shows the path of the page on the Gatsby site. Ex: Using `slug: landing-page` will cause the page to appear on the Gatsby site at `/landing-page`.
 
 - **description**: A brief, precise description of what a reader will find on the page.
 

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -83,7 +83,7 @@ The resources below have more information. They are concerned largely with forms
 
 Make sure that the link to an external page is descriptive. The user should know (or have a good idea) where the link is going to take them before they click it.
 
-When linking from one Markdown page in the `./src/docs/` folder to another, write the link in the form `/<slug of the target page>`. While these links won't work when viewing the page on GitHub, they will work on the Gatsby site.
+When linking from one Markdown page in the `./src/docs/` folder to another, write the link in the form `/<slug of the target page>/`. While these links won't work when viewing the page on GitHub, they will work on the Gatsby site.
 
 ### FAQs
 [Don't write FAQs](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/faqs) or format sections as a question and answer. Just tell the reader what they need to know.


### PR DESCRIPTION
This pull request changes the link formatting in all Markdown documents in cases where we are linking to another Markdown document in this repository (6ff0d31).

Rather than linking to the target Markdown file using its relative position in the repo (ex: `../app-monitoring/sysdig-monitor-onboarding.md`), we are now linking to the **target page's path as determined by its frontmatter `slug` field**. The `slug` field is used to build our Gatsby site's URLs: `slug: sysdig-monitoring-onboarding` in the target file's frontmatter produces an eventual URL path of `/sysdig-monitoring-onboarding/`.

This change will break links when viewing the Markdown documents in GitHub. Clicking a link to `/sysdig-monitoring-onboarding/` in the GitHub repo will result in a 404. However, we are primarily concerned with links working on the Gatsby site for the MVP launch. This functionality can be added later with a custom `gatsby-transformer-remark` plugin if we desire links that work in both GitHub and the Gatsby site. See [DevHub's `gatsby-remark-path-transformation` plugin as an example](https://github.com/bcgov/devhub-app-web/tree/master/web/plugins/gatsby-remark-path-transform).

Note the trailing slash in the new relative URL format. This is to minimize redirects in Gatsby. We are using `trailingSlash: always` in [our `./gatsby-config.js` file](https://github.com/bcgov/platform-developer-docs/blob/main/gatsby-config.js#L12), which is the default. Canonical URLs for pages will end with a trailing slash, and links that don't use the trailing slash will be redirected by Gatsby.

Instructions are added to `./tech-docs-writing-guide.md` to clarify this new linking strategy, and to include the `sort_order` frontmatter field.

This pull request solves the issue surfaced in #45 with links between Markdown documents 404ing in Gatsby.