### PR TITLE
Set autocomplete to off in search input field

### DIFF
--- a/src/components/search-bar.js
+++ b/src/components/search-bar.js
@@ -78,6 +78,7 @@ const SearchBar = () => {
         type="text"
         placeholder="Search"
         onChange={e => setQuery(e.target.value)}
+        autoComplete={"off"}
       />
       <button type="submit" aria-label="Search">
         <SearchIcon />


### PR DESCRIPTION
This pull request sets the `<input>` text field in the search bar to `autocomplete="off"`. Without this, the browser will suggest previous searches as seen below:

<img width="1840" alt="Search field with autocomplete suggestions turned on" src="https://user-images.githubusercontent.com/25143706/170078168-ac839c4f-31a6-46f2-986f-f96826922251.png">
