### PR TITLE
Add Security and Privacy Compliance nav menu

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -217,6 +217,7 @@ export default function Navigation() {
               let openshiftProjectsAndAccess = [];
               let platformArchitectureReference = [];
               let reusableCodeAndServices = [];
+              let securityAndPrivacyCompliance = [];
               let trainingAndLearning = [];
               let useGithubInBcgov = [];
               let noCategory = [];
@@ -246,6 +247,9 @@ export default function Navigation() {
                   case "reusable-code-and-services":
                     reusableCodeAndServices.push(node);
                     break;
+                  case "security-and-privacy-compliance":
+                    securityAndPrivacyCompliance.push(node);
+                    break;
                   case "training-and-learning":
                     trainingAndLearning.push(node);
                     break;
@@ -274,6 +278,7 @@ export default function Navigation() {
               openshiftProjectsAndAccess.sort(sortPages);
               platformArchitectureReference.sort(sortPages);
               reusableCodeAndServices.sort(sortPages);
+              securityAndPrivacyCompliance.sort(sortPages);
               trainingAndLearning.sort(sortPages);
               useGithubInBcgov.sort(sortPages);
               noCategory.sort(sortPages);
@@ -307,9 +312,9 @@ export default function Navigation() {
                       links={appMonitoring}
                     />
                     <NavListItem
-                      id="design-system"
-                      title="Design system"
-                      links={designSystem}
+                      id="security-and-privacy-compliance"
+                      title="Security and privacy compliance"
+                      links={securityAndPrivacyCompliance}
                     />
                     <NavListItem
                       id="reusable-code-and-services"
@@ -325,6 +330,11 @@ export default function Navigation() {
                       id="training-and-learning"
                       title="Training and learning"
                       links={trainingAndLearning}
+                    />
+                    <NavListItem
+                      id="design-system"
+                      title="Design system"
+                      links={designSystem}
                     />
                     {noCategory?.length > 0 && (
                       <NavListItem


### PR DESCRIPTION
This pull request adds a sub-menu to the Navigation component for the "Security and privacy compliance" items (08c5063). The "Design system" sub-menu is moved to the bottom of the Navigation list to match the current desired ordering in the [spreadsheet](https://docs.google.com/spreadsheets/d/1Kcp45DF63nOpkeBncsynuIh91Tj9AzSOwwp76F4GX3Q/edit#gid=804907029).

<img width="1840" alt="Screen Shot 2022-05-27 at 3 49 02 PM" src="https://user-images.githubusercontent.com/25143706/170797874-acc7281e-998b-46a6-9c42-e068f18e4d53.png">
