### PR TITLE
Fix links to Request BCGov GitHub Access page

### DIFF
--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -85,7 +85,7 @@ Related links:
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [GitHub Enterprise user licences in the BC government](/github-enterprise-user-licenses-bc-government/)
 * [Remove a user's BCGov GitHub access](/remove-user-bcgov-github-access/)
-* [Request BCGov GitHub access or repository creation](/request-bcgov-github-access-repository-creation/)
+* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
+++ b/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
@@ -40,7 +40,7 @@ GitHub User Access Removal Request:
 Related links:
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [BC Government organizations in GitHub](/bc-government-organizations-in-github/)
-* [Request BCGov GitHub access or repository creation](/request-bcgov-github-access-repository-creation/)
+* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -159,9 +159,11 @@ const IndexPage = () => {
                 </Link>
               </li>
               <li>
-                <Link to={"/request-bcgov-github-access-repository-creation"}>
-                  Request access to BCGov org in GitHub
-                </Link>
+                <a
+                  href={`${WORDPRESS_BASE_URL}/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/`}
+                >
+                  Common platform requests in the BC Gov Private Cloud PaaS
+                </a>
               </li>
               <li>Best practices for working in GitHub (coming soon)</li>
             </ul>

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -65,9 +65,9 @@ Don't duplicate content across pages. Remember the principle of **one topic = on
 
 For example, from our own tech docs library: [BC Government organizations in GitHub](https://github.com/bcgov/platform-developer-docs/blob/main/docs/use-github-in-bcgov/bc-government-organizations-in-github.md). The first draft of this page originally contained three topics:
 
-- [BC Government organizations in GitHub](https://github.com/bcgov/platform-developer-docs/blob/main/docs/use-github-in-bcgov/bc-government-organizations-in-github.md)
-- [Remove a user's BCGov GitHub access](https://github.com/bcgov/platform-developer-docs/blob/main/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md)
-- [Request BCGov GitHub access or repository creation](https://github.com/bcgov/platform-developer-docs/blob/main/docs/use-github-in-bcgov/request-bcgov-github-access-repository-creation.md)
+- [BC Government organizations in GitHub](https://github.com/bcgov/platform-developer-docs/blob/main/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md)
+- [Remove a user's BCGov GitHub access](https://github.com/bcgov/platform-developer-docs/blob/main/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md)
+- [Request BCGov GitHub access or repository creation](https://github.com/bcgov/platform-developer-docs/commit/40ddd75ed72cb4599a119e581df9b7a668a774b3)
 
 After getting feedback, these pages needed to be split. Each page now seems pretty clear what they're about and the user doesn't have to wade through the original page to find content on requests or removals.
 


### PR DESCRIPTION
The content from the page "Request BCGov GitHub access or repository creation" was [deleted in this commit from May 26](https://github.com/bcgov/platform-developer-docs/commit/40ddd75ed72cb4599a119e581df9b7a668a774b3) after being moved to the Private Cloud PaaS WordPress site page ["Common platform requests in the BC Gov Private Cloud PaaS"](https://platform-services-dev.apps.silver.devops.gov.bc.ca/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/). This pull request updates link that were pointing to the now-deleted internal page, pointing them to the WordPress page instead. (5c9dec9)

Additionally, the Tech Docs Writing Guide doc has its internal document links updated to point to either the live documents in the main branch of this repository, or to the deletion commit in the case of the "Request BCGov GitHub access" page. (bf561b8)