### PR TITLE
Load spinner component for search result page

### DIFF
--- a/src/components/load-spinner.js
+++ b/src/components/load-spinner.js
@@ -1,0 +1,68 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const LoadSpinnerGroupContainer = styled.div`
+  width: 100%;
+`;
+
+const StyledSpinner = styled.div`
+  height: auto;
+  padding: 0.8em 1em;
+  width: 100%;
+
+  div {
+    border-radius: 0.5em;
+    margin-bottom: 0.5em;
+    animation: pulse 1s infinite;
+
+    &.url {
+      height: 0.8em;
+      width: 80%;
+    }
+    &.title {
+      height: 1.2em;
+      width: 60%;
+    }
+    &.snippet {
+      height: 3em;
+      width: 100%;
+    }
+  }
+
+  @keyframes pulse {
+    0% {
+      background-color: #f8f8f8;
+    }
+    50% {
+      background-color: #e8e8e8;
+    }
+    100% {
+      background-color: #f8f8f8;
+    }
+  }
+`;
+
+const Spinner = () => {
+  return (
+    <StyledSpinner>
+      <div className="url" />
+      <div className="title" />
+      <div className="snippet" />
+    </StyledSpinner>
+  );
+};
+
+export default function LoadSpinnerGroup({ count }) {
+  return (
+    <LoadSpinnerGroupContainer>
+      {[...Array(count)].map((e, i) => {
+        return <Spinner key={`spinner-${i}`} />;
+      })}
+    </LoadSpinnerGroupContainer>
+  );
+}
+
+LoadSpinnerGroup.propTypes = {
+  count: PropTypes.number.isRequired,
+};

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 
 import Alert from "../components/alert";
 import Layout from "../components/layout";
+import LoadSpinnerGroup from "../components/load-spinner";
 import Pagination from "../components/pagination";
 import Seo from "../components/seo";
 
@@ -151,9 +152,12 @@ const SearchPage = () => {
         <h1>Search</h1>
 
         {isLoading ? (
-          <p>
-            Loading results for <strong>{query}</strong>
-          </p>
+          <>
+            <p>
+              Loading results for <strong>{query}</strong>
+            </p>
+            <LoadSpinnerGroup count={3} />
+          </>
         ) : (
           <>
             {parseInt(results?.searchInformation?.totalResults) > pageSize ? (


### PR DESCRIPTION
This pull request adds a visual load spinner animation to the search result page during the time period where `isLoading` is true. This happens when the page itself has loaded but the API request to the search engine hasn't returned any results.

https://user-images.githubusercontent.com/25143706/175428330-adadfa26-f729-4b58-9a5f-f6ba6020f042.mov

- LoadSpinnerGroup component is added (bcdb252)
- LoadSpinnerGroup is used on search result page (e1fa410)