### PR TITLE
Fix internal link formatting in content pages

### DIFF
--- a/src/docs/automation-and-resiliency/application-resource-tuning.md
+++ b/src/docs/automation-and-resiliency/application-resource-tuning.md
@@ -20,12 +20,12 @@ sort_order: 2
 
 # Application resource tuning
 
-As touched upon in the [resiliency guidelines](/App-Resiliency-Guidelines#resourced), deploying applications with appropriate [CPU and memory requests and limits](https://docs.openshift.com/container-platform/3.11/admin_guide/overcommit.html#requests-and-limits) is critical to ensure:
+As touched upon in the [resiliency guidelines](/app-resiliency-guidelines/), deploying applications with appropriate [CPU and memory requests and limits](https://docs.openshift.com/container-platform/3.11/admin_guide/overcommit.html#requests-and-limits) is critical to ensure:
 
 * Resource availability for your own applications
 * Resource availability for other tenant applications
 
-While [resource quotas](./src/docs/automation-and-resiliency/openshift-project-resource-quotas) are quite generous, these quotas must be seen as a tool to allow tenants enough resources to temporarily burst usage for experimentation, rather than an upper limit of consistent use. The platform is not sized to support every tenant fully utilizing their _resource quota_.
+While [resource quotas](/openshift-project-resource-quotas/) are quite generous, these quotas must be seen as a tool to allow tenants enough resources to temporarily burst usage for experimentation, rather than an upper limit of consistent use. The platform is not sized to support every tenant fully utilizing their _resource quota_.
 
 **Resource requests**  
 Resource requests are guaranteed and reserved for the pod. _Pod scheduling decisions are made based on the request_ to ensure that a node has enough capacity available to meet the requested value. Inefficient use of requests lead to having to buy more licenses and hardware for the platform.

--- a/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
+++ b/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
@@ -77,7 +77,7 @@ storage-512 Overall Storage: 512 GiB, Backup Storage: 256 GiB
 ```
 ---
 Related links:
-* [Request a quota increase for an OpenShift project set](./openshift-project-resource-quotas/)
+* [Request a quota increase for an OpenShift project set](/openshift-project-resource-quotas/)
 * [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing)
 
 Rewrite sources:

--- a/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
+++ b/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
@@ -182,7 +182,7 @@ Understand:
 
 ---
 Related links:
-- [Vault Secrets Management Service](/vault-secrets-management-service)
+- [Vault Secrets Management Service](/vault-secrets-management-service/)
 - [Linux Foundation OSS Security Badges](https://github.com/linuxfoundation/cii-best-practices-badge)
 - [Unix, PHP, Python and general programing](http://www.dwheeler.com/secure-programs/Secure-Programs-HOWTO/index.html)
 - [Java](https://www.java.com/en/security/developer-info.jsp)

--- a/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
+++ b/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
@@ -116,7 +116,7 @@ An STRA for Vault has been completed by the Platform Services team.
 
 ---
 Related links:
-[Security Best Practices For Apps](./security-best-practices-for-apps.md)
+[Security Best Practices For Apps](/security-best-practices-for-apps/)
 
 Rewrite sources:
 * https://developer.gov.bc.ca/Platform-Services-Security/BC-Government-Vault-Secrets-Management


### PR DESCRIPTION
All of these link updates are to fix links that were either 404ing or causing unnecessary re-directs.

When an internal link doesn't end with a trailing slash after the slug portion of the URL, this causes a re-direct to the equivalent correct URL (ex: `/app-monitoring` will cause an unnecessary redirect to `/app-monitoring/`).