### PR TITLE
Footer links and mobile styling

### DIFF
--- a/src/components/__tests__/__snapshots__/footer.js.snap
+++ b/src/components/__tests__/__snapshots__/footer.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer renders correctly 1`] = `
+<footer
+  className="sc-bczRLJ jSDzGT"
+>
+  <div
+    className="sc-gsnTZi hPKblw"
+  >
+    <nav>
+      <ul>
+        <li>
+          <a
+            href="/"
+          >
+            Home
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www2.gov.bc.ca/gov/content?id=79F93E018712422FBC8E674A67A70535"
+          >
+            Disclaimer
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www2.gov.bc.ca/gov/content?id=9E890E16955E4FF4BF3B0E07B4722932"
+          >
+            Privacy
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www2.gov.bc.ca/gov/content?id=E08E79740F9C41B9B0C484685CC5E412"
+          >
+            Accessibility
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://www2.gov.bc.ca/gov/content?id=1AAACC9C65754E4D89A118B875E0FBDA"
+          >
+            Copyright
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://github.com/bcgov/platform-developer-docs/issues"
+          >
+            Contact Us
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</footer>
+`;

--- a/src/components/__tests__/footer.js
+++ b/src/components/__tests__/footer.js
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import Footer from "../footer";
+
+describe("Footer", () => {
+  const testRenderer = renderer.create(<Footer />);
+
+  it("renders correctly", () => {
+    expect(testRenderer.toJSON()).toMatchSnapshot();
+  });
+
+  it("contains 6 links", () => {
+    expect(testRenderer.root.findAllByType("a").length).toEqual(6);
+  });
+});

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -51,8 +51,18 @@ const StyledFooter = styled.footer`
         flex-direction: column;
         align-items: baseline;
 
-        li > a {
-          border-right: none;
+        li {
+          a {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            border-right: none;
+            min-height: 44px;
+          }
+
+          &:last-child {
+            margin-bottom: 1em;
+          }
         }
       }
     }

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -101,7 +101,10 @@ const Footer = () => (
             </a>
           </li>
           <li>
-            <a href=".">Contact Us</a>
+            {/* GitHub link to repository Issues page */}
+            <a href="https://github.com/bcgov/platform-developer-docs/issues">
+              Contact Us
+            </a>
           </li>
         </ul>
       </nav>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Link } from "gatsby";
 import styled from "styled-components";
 
 const StyledFooter = styled.footer`
@@ -74,7 +75,7 @@ const Footer = () => (
       <nav>
         <ul>
           <li>
-            <a href=".">Home</a>
+            <Link to={"/"}>Home</Link>
           </li>
           <li>
             {/* CMS Lite permalink to https://www2.gov.bc.ca/gov/content/home/disclaimer */}

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -77,16 +77,28 @@ const Footer = () => (
             <a href=".">Home</a>
           </li>
           <li>
-            <a href=".">Disclaimer</a>
+            {/* CMS Lite permalink to https://www2.gov.bc.ca/gov/content/home/disclaimer */}
+            <a href="https://www2.gov.bc.ca/gov/content?id=79F93E018712422FBC8E674A67A70535">
+              Disclaimer
+            </a>
           </li>
           <li>
-            <a href=".">Privacy</a>
+            {/* CMS Lite permalink to https://www2.gov.bc.ca/gov/content/home/privacy */}
+            <a href="https://www2.gov.bc.ca/gov/content?id=9E890E16955E4FF4BF3B0E07B4722932">
+              Privacy
+            </a>
           </li>
           <li>
-            <a href=".">Accessibility</a>
+            {/* CMS Lite permalink to https://www2.gov.bc.ca/gov/content/home/accessible-government */}
+            <a href="https://www2.gov.bc.ca/gov/content?id=E08E79740F9C41B9B0C484685CC5E412">
+              Accessibility
+            </a>
           </li>
           <li>
-            <a href=".">Copyright</a>
+            {/* CMS Lite permalink to https://www2.gov.bc.ca/gov/content/home/copyright */}
+            <a href="https://www2.gov.bc.ca/gov/content?id=1AAACC9C65754E4D89A118B875E0FBDA">
+              Copyright
+            </a>
           </li>
           <li>
             <a href=".">Contact Us</a>


### PR DESCRIPTION
This pull request updates the site Footer component to add correct `href` values to each link. 

The Disclaimer, Privacy, Accessibility, and Copyright links point to the core government statements (per the [Requirements section of the Footer component in the design system](https://developer.gov.bc.ca/Design-System/Footer-Basic#requirements)) (40eb60c). For the Contact Us link, I've used the [Issues](https://github.com/bcgov/platform-developer-docs/issues) section of this repository to mirror the current behavior on DevHub (36d8a85). The Home link points to the site root, but it now uses a Gatsby Reach Router `<Link>` component to a page reload (f9b12b3).

On mobile, I've increased the target size of each link to a minimum of 44px high for accessibility (d6ec3d4):

<img width="444" alt="Footer shown on Chrome emulated iPhone SE screen" src="https://user-images.githubusercontent.com/25143706/176020846-ba9271a7-9be8-4b20-a404-6e4edfde8bec.png">

For testing, I've added a snapshot test and check for the correct number of links in the Footer. (1058db5)

