### PR TITLE
Enable gzip in nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,6 +21,9 @@ http {
     server_name _;
     port_in_redirect off;
 
+    gzip on;
+    gzip_types *;
+
     index index.html;
     error_log  /tmp/error.log;
     access_log /tmp/access.log;


### PR DESCRIPTION
This pull request updates the `./nginx.conf` configuration file to use `gzip` compression on all responses (HTML, plaintext, JavaScript, etc).

Prior to enabling compression, Google Lighthouse is unhappy with the time spent receiving uncompressed data:
<img width="1840" alt="Google Lighthouse screenshot showing a test of the current production site in mobile mode" src="https://user-images.githubusercontent.com/25143706/176039889-b065b1b1-d0ab-4b55-8fd8-709bb78dba42.png">

After this new configuration is applied, this test passes:
<img width="1840" alt="Google Lighthouse screenshot showing a test of the updated nginx configuration on localhost" src="https://user-images.githubusercontent.com/25143706/176040330-d84c9ef9-c748-46b3-af96-ffe55321faf4.png">
