### PR TITLE
Use Gatsby location object to render Navigation menu

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -64,7 +64,7 @@ const StyledSkipNavContent = styled(SkipNavContent)`
   }
 `;
 
-const Layout = ({ children }) => {
+const Layout = ({ children, location }) => {
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
       site {
@@ -81,7 +81,7 @@ const Layout = ({ children }) => {
       <StyledSkipNavLink>Skip to main content</StyledSkipNavLink>
       <Header siteTitle={data.site.siteMetadata?.title || `Title`} />
       <FlexContainer>
-        <Navigation />
+        <Navigation location={location} />
         <StyledSkipNavContent>{children}</StyledSkipNavContent>
       </FlexContainer>
       <Footer />
@@ -91,6 +91,9 @@ const Layout = ({ children }) => {
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default Layout;

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -76,8 +76,7 @@ const StyledListItem = styled.li`
   }
 `;
 
-const NavListItem = ({ id, links, title }) => {
-  const path = typeof window !== "undefined" ? window.location.pathname : "";
+const NavListItem = ({ id, links, path, title }) => {
   const isContainingCurrentPage = links.some(link =>
     path.includes(link.frontmatter.slug)
   );
@@ -165,9 +164,10 @@ const StyledDiv = styled.div`
   }
 `;
 
-export default function Navigation() {
+export default function Navigation({ location }) {
   const isSmallScreen = useMediaQuery({ query: "(max-width: 767.98px)" });
   const [isOpen, setIsOpen] = useState(!isSmallScreen);
+  const path = location.pathname;
 
   return (
     <>
@@ -290,57 +290,68 @@ export default function Navigation() {
                       id="build-deploy-and-maintain-apps"
                       title="Build, deploy and maintain apps"
                       links={buildDeployAndMaintainApps}
+                      path={path}
                     />
                     <NavListItem
                       id="openshift-projects-and-access"
                       title="OpenShift projects and access"
                       links={openshiftProjectsAndAccess}
+                      path={path}
                     />
                     <NavListItem
                       id="use-github-in-bc-gov"
                       title="Use GitHub in BC Gov"
                       links={useGithubInBcgov}
+                      path={path}
                     />
                     <NavListItem
                       id="automation-and-resiliency"
                       title="Automation and resiliency"
                       links={automationAndResiliency}
+                      path={path}
                     />
                     <NavListItem
                       id="app-monitoring"
                       title="App monitoring"
                       links={appMonitoring}
+                      path={path}
                     />
                     <NavListItem
                       id="security-and-privacy-compliance"
                       title="Security and privacy compliance"
                       links={securityAndPrivacyCompliance}
+                      path={path}
                     />
                     <NavListItem
                       id="reusable-code-and-services"
                       title="Reusable code and services"
                       links={reusableCodeAndServices}
+                      path={path}
                     />
                     <NavListItem
                       id="platform-architecture-reference"
                       title="Platform architecture reference"
                       links={platformArchitectureReference}
+                      path={path}
                     />
                     <NavListItem
                       id="training-and-learning"
                       title="Training and learning"
                       links={trainingAndLearning}
+                      path={path}
                     />
                     <NavListItem
                       id="design-system"
                       title="Design system"
                       links={designSystem}
+                      path={path}
                     />
                     {noCategory?.length > 0 && (
                       <NavListItem
                         id="uncategorized"
                         title="Uncategorized"
                         links={noCategory}
+                        path={path}
                       />
                     )}
                   </ul>
@@ -355,9 +366,13 @@ export default function Navigation() {
 }
 
 Navigation.propTypes = {
-  links: PropTypes.array,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 Navigation.defaultProps = {
-  links: [],
+  location: {
+    pathname: "/",
+  },
 };

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import Layout from "../components/layout";
 import Seo from "../components/seo";
 
-const NotFoundPage = () => (
-  <Layout>
+const NotFoundPage = ({ location }) => (
+  <Layout location={location}>
     <Seo title="404: Not found" />
     <h1>404: Not Found</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,7 +35,7 @@ const Card = styled.div`
   border: 1px solid rgb(225, 225, 225);
 `;
 
-const IndexPage = () => {
+const IndexPage = ({ location }) => {
   const data = useStaticQuery(graphql`
     query IndexSiteTitleQuery {
       site {
@@ -47,7 +47,7 @@ const IndexPage = () => {
   `);
 
   return (
-    <Layout>
+    <Layout location={location}>
       <Seo title="Home" />
       <main>
         <h1>Welcome to the {data.site.siteMetadata.title || `Title`}</h1>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -78,7 +78,7 @@ const StyledList = styled.ol`
   margin-left: 0;
 `;
 
-const SearchPage = () => {
+const SearchPage = ({ location }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
   const [results, setResults] = useState({});
@@ -143,7 +143,7 @@ const SearchPage = () => {
   }
 
   return (
-    <Layout>
+    <Layout location={location}>
       <Seo
         title={`Search: ${query}`}
         meta={[{ name: "robots", content: "noindex" }]} // Search pages should be excluded from public search engines

--- a/src/pages/{MarkdownRemark.frontmatter__slug}.js
+++ b/src/pages/{MarkdownRemark.frontmatter__slug}.js
@@ -5,12 +5,13 @@ import Layout from "../components/layout";
 import Seo from "../components/seo";
 
 export default function Template({
-  data, // this prop will be injected by the GraphQL query below.
+  data, // injected by the GraphQL query: https://www.gatsbyjs.com/docs/working-with-images-in-markdown/#inline-images-with-gatsby-remark-images
+  location, // supplied by Gatsby to top-level page components: https://www.gatsbyjs.com/docs/location-data-from-props/
 }) {
   const { markdownRemark } = data; // data.markdownRemark holds your post data
   const { frontmatter, html } = markdownRemark;
   return (
-    <Layout>
+    <Layout location={location}>
       <Seo
         title={frontmatter?.title}
         description={frontmatter?.description}


### PR DESCRIPTION
This pull request refactors the way the Navigation component reads the current page path to decide which sub-menu should appear open.

Before this change, the page location information is being read from the `window` object. If a Navigation menu sub-menu contains a link to the current page, that sub-menu appears expanded with the current page highlighted:

<img width="1840" alt="Screenshot showing intended Navigation menu behavior" src="https://user-images.githubusercontent.com/25143706/176775848-f908b29e-47b8-4a1e-b959-bc21be4eadb7.png">

This functionality works the majority of the time, but doesn't work in the specific use case of clicking through a Google search engine result to a page on the Tech Docs site. While the path information will be read from `window` on subsequent pages, the first page that gets visited will have all the sub-menus collapsed:

<img width="1840" alt="Screen Shot 2022-06-30 at 1 51 53 PM" src="https://user-images.githubusercontent.com/25143706/176776257-f6f044f1-103c-42b2-86b3-1e924d9eb68e.png">

This is confusing, as the user has no idea which sub-menu might contain the current page. Without any other visual affordance, they are left to click around to figure out where they are in the information architecture.

This pull request attempts to rectify this by reading the current page path from the [`location` prop](https://www.gatsbyjs.com/docs/location-data-from-props/) that Gatsby injects into top-level page components. This should be more robust that trying to read from the `window` object. `window` is not available outside of the browser environment, so this change should be better for future integration tests as well.

I won't be able to test this fix until this code is live on the production site, as I'm unable to reproduce this bug locally.

- Top level page components pass their `location` prop to the child `<Layout>` component (1816dbb)
- `<Layout>` component passes `location` prop to `<Navigation>` component (b38ccd5)
- `<Navigation>` component gets refactored to use Gatsby `location` instead of browser `window` object (fe0be65)