### PR TITLE
Fix typos and broken links

### DIFF
--- a/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
+++ b/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
@@ -48,7 +48,7 @@ PromQL can be used in Alerts as well. The following example shows an alert for t
 
 ## Use Service Discovery to import application metrics endpoints<a name="sysdig-service-discovery"></a>
 
-Sysdig has a lightweight Prometheus server (Promscrape) that can [import your application metrics endpoint into Sysdig metrics](https://docs.sysdig.com/en/docs/sysdig-monitor/integrations-for-sysdig-monitor/configure-monitoring-integrations/migrating-from-promscrape-v1-to-v2/#migrate-using-default-configuration).
+Sysdig has a lightweight Prometheus server (Promscrape) that can [import your application metrics endpoint into Sysdig metrics](https://docs.sysdig.com/en/docs/sysdig-monitor/monitoring-integrations/custom-integrations/collect-prometheus-metrics/migrating-from-promscrape-v1-to-v2/#migrate-using-default-configuration).
 
 To enable Promscrape to find your application metrics, do the following:
 1. Make sure the application metrics endpoint is returning Prometheus metrics. To test this, you can expose the service and curl on the URL.
@@ -69,7 +69,7 @@ Related links:
 - [Set up a team in Sysdig Monitor](/sysdig-monitor-setup-team/)
 - [Create alert channels in Sysdig Monitor](/sysdig-monitor-create-alert-channels/)
 - [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
-- [Migrate Using Default Configuration](https://docs.sysdig.com/en/docs/sysdig-monitor/integrations-for-sysdig-monitor/configure-monitoring-integrations/migrating-from-promscrape-v1-to-v2/#migrate-using-default-configuration)
+- [Migrate Using Default Configuration](https://docs.sysdig.com/en/docs/sysdig-monitor/monitoring-integrations/custom-integrations/collect-prometheus-metrics/migrating-from-promscrape-v1-to-v2/#migrate-using-default-configuration)
 
 Related resources:
 - [Sysdig Monitor](https://docs.sysdig.com/en/sysdig-monitor.html)

--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -68,7 +68,7 @@ There are plenty of options for ensuring that this change in approach helps your
 
 ## An Easily Deployable App<a name="easily-deployable"></a>
 
-Because all applications on OpenShift should be architected with the expectation that any node can go down at any time, it's imperative that applications be easy and quick to redeploy, requiring - most importantly - **no human interaction in the process**. Once the platform is given the command to deploy your software on a new pod, the process between starting up that new pod and having an accessible and useable app should require no human interference whatsoever.
+Because all applications on OpenShift should be architected with the expectation that any node can go down at any time, it's imperative that applications be easy and quick to redeploy, requiring - most importantly - **no human interaction in the process**. Once the platform is given the command to deploy your software on a new pod, the process between starting up that new pod and having an accessible and usable app should require no human interference whatsoever.
 
 This means that all of your deployment configuration should be automated and kept in source-control to ensure that it is easily accessible, consistent, and up-to-date at all times! And that includes any side processes like your monitoring tasks from the section above!
 

--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -54,7 +54,7 @@ The best way to keep on top of these issues in a proactive manner is to monitor 
 
 Many of these notification options provide your team an opportunity to act to prevent an outage before one even starts - finding out, for example, that your storage is almost full _before_ it fills up means that your team can act to deal with the storage issue _before_ it causes an outage or service issue. Still others let you know the moment an outage starts and can provide extremely valuable information about the cause of the outage, so your team can begin troubleshooting right away without having to wait for users to inform you of the problem.
 
-Your team should also ensure you are in the [#devops-alerts channel](https://chat.pathfinder.gov.bc.ca/channel/devops-alerts) in RocketChat where notices of upcoming maintenance are posted. The channel is quite low volume, so it may be worth turning up your RocketChat notification settings for the channel to **All messages**.
+Your team should also ensure you are in the [#devops-alerts channel](https://chat.developer.gov.bc.ca/channel/devops-alerts) in RocketChat where notices of upcoming maintenance are posted. The channel is quite low volume, so it may be worth turning up your RocketChat notification settings for the channel to **All messages**.
 
 ## A Highly Available App<a name="highly-available"></a>
 

--- a/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
+++ b/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
@@ -43,7 +43,7 @@ Currently, the following technologies are available to product teams:
 - [GitHub Actions](https://github.com/bcgov/security-pipeline-templates/tree/main/.github/workflows)
 - [Openshift Pipelines (Tekton)](https://github.com/bcgov/security-pipeline-templates/tree/main/tekton)
 
-While Jenkins is technically supported on the platform the Platform Services team highly discourages teams from using this technology as it's inefficient with the use of valuable platform resources. Over the next few months we'll be guiding the teams that currently use Jenkins to transition to a more modern and efficient technology.
+While Jenkins is technically supported on the platform, the Platform Services team highly discourages teams from using this technology as it's inefficient with the use of valuable platform resources. Over the next few months we'll be guiding the teams that currently use Jenkins to transition to a more modern and efficient technology.
 
 ## Choose a technology<a name="choose-technology"></a>
 

--- a/src/docs/automation-and-resiliency/prepare-to-load-test-application-on-openshift.md
+++ b/src/docs/automation-and-resiliency/prepare-to-load-test-application-on-openshift.md
@@ -58,7 +58,3 @@ Submitting a comprehensive test plan that includes this information as part of y
 The Platform Services team reviews your test to ensure it meets the requirements and also confirms that no other product team has a load test scheduled at the same time.
 
 Contact the Platform Services team at [PlatformServicesTeam@gov.bc.ca](mailto:PlatformServicesTeam@gov.bc.ca) to submit your request to schedule your load test.
----
-Rewrite sources:
-* https://github.com/bcgov/platform-developer-docs/tree/review-technical-docs
----

--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -78,7 +78,7 @@ Use the following process:
   - Current quota in the project set
   - Total CPU, memory or storage currently used
   - Expected quota increase amount with a detailed allocation plan
-5. Email the request to the Platform Services team at [PlatformServicesTeam@gov.bc.ca](PlatformServicesTeam@gov.bc.ca). Make sure you provide the Sysdig dashboard and ask to book a meeting.
+5. Email the request to the Platform Services team at [PlatformServicesTeam@gov.bc.ca](mailto:PlatformServicesTeam@gov.bc.ca). Make sure you provide the Sysdig dashboard and ask to book a meeting.
 
   If you need to store a large amount of unstructured data, consider using the [S3 Object Storage Service](https://github.com/BCDevOps/OpenShift4-Migration/issues/59) provided by Enterprise Hosting.
 

--- a/src/docs/build-deploy-and-maintain-apps/image-artifact-management-with-artifactory.md
+++ b/src/docs/build-deploy-and-maintain-apps/image-artifact-management-with-artifactory.md
@@ -88,11 +88,11 @@ Privacy Impact Assessment (PIA) and Security Threat Risk Assessment (STRA) have 
 ## Artifactory support, processes, and communications<a name="support-processes-comms"></a>
 The team supporting this service administers the Artifactory application, its supporting database and the S3 storage system that contains the packages uploaded to Artifactory.
 
-Your best source for support, configuration and best practices is the developer community that uses Artifactory for their projects. Check out the [`#devops-artifactory` channel on Rocket.Chat](https://chat.pathfinder.gov.bc.ca/channel/devops-artifactory). Service changes are also posted here.
+Your best source for support, configuration and best practices is the developer community that uses Artifactory for their projects. Check out the [`#devops-artifactory` channel on Rocket.Chat](https://chat.developer.gov.bc.ca/channel/devops-artifactory). Service changes are also posted here.
 
-For further support in the event of an emergency or outage, contact one of the Artifactory administrators on the [`#devops-sos` channel on Rocket.Chat](https://chat.pathfinder.gov.bc.ca/channel/devops-sos).
+For further support in the event of an emergency or outage, contact one of the Artifactory administrators on the [`#devops-sos` channel on Rocket.Chat](https://chat.developer.gov.bc.ca/channel/devops-sos).
 
-For cluster-wide service notifications that could impact Artifactory, monitor the [`#devops-alerts` channel in Rocket.Chat](https://chat.pathfinder.gov.bc.ca/channel/devops-alerts).
+For cluster-wide service notifications that could impact Artifactory, monitor the [`#devops-alerts` channel in Rocket.Chat](https://chat.developer.gov.bc.ca/channel/devops-alerts).
 
 ## Service improvements and disruptions<a name="service-improvements"></a>
 
@@ -111,9 +111,9 @@ Related links:
 * [JFROG documentation](https://www.jfrog.com/confluence/site/documentation)
 * [Privacy Impact Assessment (PIA)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/privacy-impact-assessments)
 * [Security Threat Risk Assessment (STRA)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/security-threat-and-risk-assessment)
-* [#devops-artifactory](https://chat.pathfinder.gov.bc.ca/channel/devops-artifactory)
-* [#devops-sos](https://chat.pathfinder.gov.bc.ca/channel/devops-sos)
-* [#devops-alerts](https://chat.pathfinder.gov.bc.ca/channel/devops-alerts)
+* [#devops-artifactory](https://chat.developer.gov.bc.ca/channel/devops-artifactory)
+* [#devops-sos](https://chat.developer.gov.bc.ca/channel/devops-sos)
+* [#devops-alerts](https://chat.developer.gov.bc.ca/channel/devops-alerts)
 * [Setup an Artifactory service account](/setup-artifactory-service-account/)
 * [Setup an Artifactory project and repository](/setup-artifactory-project-repository/)
 

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
@@ -120,7 +120,7 @@ Your new repository is set up. If you would like your Artifactory Service Accoun
 
 ---
 Related links:
-* [Archeobot](bcgov/platform-services-archeobot)
+* [Archeobot](https://github.com/bcgov/platform-services-archeobot)
 * [Artifactory](https://artifacts.developer.gov.bc.ca)
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [Setup an Artifactory service account](/setup-artifactory-service-account/)

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
@@ -30,7 +30,7 @@ Artifactory access is controlled through Artifactory service accounts. Service a
 
 ## Archeobot<a name="archeobot"></a>
 
-[Archeobot](bcgov/platform-services-archeobot) is a custom operator that gives teams the freedom to manage their own Artifactory resources. Archeobot can be used to:
+[Archeobot](https://github.com/bcgov/platform-services-archeobot) is a custom operator that gives teams the freedom to manage their own Artifactory resources. Archeobot can be used to:
 * Create new Artifactory service accounts.
 * Request new Artifactory projects.
 * Request quota changes to existing Artifactory projects.

--- a/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
+++ b/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
@@ -20,7 +20,7 @@ sort_order: 2
 
 # Grant user access in OpenShift
 
-Access to the the OpenShift platform is self-serve and is available to IDIR users and members of the bcgov organization in GitHub. The platform provides platform and namespace-level access control. Access to the platform requires certain prerequisites and mechanisms to grant access.
+Access to the OpenShift platform is self-serve and is available to IDIR users and members of the bcgov organization in GitHub. The platform provides platform and namespace-level access control. Access to the platform requires certain prerequisites and mechanisms to grant access.
 
 Existing bcgov organization members can invite other users to the organization. Every team member may not need access to OpenShift. Consider the security principle of least privilege before requesting platform access and when granting namespace-level access.
 

--- a/src/docs/platform-architecture-reference/platform-storage.md
+++ b/src/docs/platform-architecture-reference/platform-storage.md
@@ -39,7 +39,7 @@ We have access to the following storage services for the OpenShift platform.
 
 ### OpenShift Persistent Volumes (NetApp)
 
-All NetApp storage classes support resizing (bigger only). You can start with a small volume and edit your Persisent Volume Claim (PVC) to have a larger `.spec.resources.requests.storage` later if you need more. You may need to restart the pods attached to let the resize trigger on re-mount. **Note: the storage increase is capped by the storage quota assigned to the namespace. For the current resource quota sizes, see [OpenShift project resource quotas](/openshift-project-resource-quotas/).
+All NetApp storage classes support resizing (bigger only). You can start with a small volume and edit your Persistent Volume Claim (PVC) to have a larger `.spec.resources.requests.storage` later if you need more. You may need to restart the pods attached to let the resize trigger on re-mount. **Note: the storage increase is capped by the storage quota assigned to the namespace. For the current resource quota sizes, see [OpenShift project resource quotas](/openshift-project-resource-quotas/).
 
 * **NetApp File**: `netapp-file-standard` is the default storage class for the platform and the type of storage you get if you don't specify a specific `storageClass`.
 

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -142,7 +142,7 @@ SonarQube is a community-supported service. We also encourage teams to switch to
 For more information, see [SonarQube Best Practices](https://developer.gov.bc.ca/Platform-Services-Security/SonarQube-Best-Practices). You can also review the [SonarQube repository](https://github.com/BCDevOps/sonarqube)
 
 ## SonarQube on OpenShift<a name="sq-openshift"></a>
-The [sonarqube repository](https://github.com/BCDevOps/sonarqube) contains all the resources you might need to deploy a SonarQube server instance in a B.C. government OpenShift pathfinder environment and integrate SonarQube scanning into your Jenkins pipeline.
+The [sonarqube repository](https://github.com/BCDevOps/sonarqube) contains all the resources you might need to deploy a SonarQube server instance in a B.C. government OpenShift environment and integrate SonarQube scanning into your Jenkins pipeline.
 
 This work was inspired by the [OpenShift Demos SonarQube for OpenShift](https://github.com/OpenShiftDemos/sonarqube-openshift-docker).
 

--- a/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
+++ b/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
@@ -86,7 +86,7 @@ Understand:
 
 * Scope and timeline of the assessment
 * Criticality of the system
-  * consider Confidentiality, Integrity and Availablity requirements
+  * consider Confidentiality, Integrity and Availability requirements
   * consider whether the system is a [Critical System](https://www2.gov.bc.ca/assets/gov/british-columbians-our-governments/services-policies-for-government/information-management-technology/information-security/defensible-security/critical_systems_standard.pdf)
 
 ### Asset Management
@@ -184,7 +184,7 @@ Understand:
 Related links:
 - [Vault Secrets Management Service](/vault-secrets-management-service/)
 - [Linux Foundation OSS Security Badges](https://github.com/linuxfoundation/cii-best-practices-badge)
-- [Unix, PHP, Python and general programing](http://www.dwheeler.com/secure-programs/Secure-Programs-HOWTO/index.html)
+- [Unix, PHP, Python and general programming](http://www.dwheeler.com/secure-programs/Secure-Programs-HOWTO/index.html)
 - [Java](https://www.java.com/en/security/developer-info.jsp)
 - [MSDN: Windows & .NET](https://msdn.microsoft.com/en-us/library/zdh19h94(v=vs.140).aspx)
 - [WordPress](http://stevegrunwell.github.io/wordpress-security-basics/#/)

--- a/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
+++ b/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
@@ -26,7 +26,7 @@ Non-secrets may be stored in Vault if desired.
 
 ## On this page
 - [Features and Functions](#features-and-functions)
-- [Eligibility and Prerequesites](#eligibility-and-prerequesites)
+- [Eligibility and Prerequisites](#eligibility-and-prerequisites)
 - [How to Request](#how-to-request)
 - [Availability](#availability)
 - [How do I get help?](#how-do-i-get-help)
@@ -53,9 +53,9 @@ All secrets in Vault have a lease associated with them. At the end of the lease,
 ### Revocation:
 Vault has built-in support for secret revocation. Vault can revoke not only single secrets, but a tree of secrets, for example all secrets read by a specific user, or all secrets of a particular type. Revocation assists in key rolling as well as locking down systems in the case of an intrusion.
 
-## Eligibility and Prerequisites <a name="eligibility-and-prerequesites"></a>
+## Eligibility and Prerequisites <a name="eligibility-and-prerequisites"></a>
 
-Development teams are provisioned a Vault service account for each environment (dev, test, prod, and tools) through the automation backing the [Platform Services Registry](https://registry.developer.gov.bc.ca/public-landing). Each ProjectSet created in the Registry can have up to two technical contacts assosicated with it, these technical contacts are given write access to Vault and can manage secrets within a ProjectSet's two mount points (nonprod, prod).
+Development teams are provisioned a Vault service account for each environment (dev, test, prod, and tools) through the automation backing the [Platform Services Registry](https://registry.developer.gov.bc.ca/public-landing). Each ProjectSet created in the Registry can have up to two technical contacts associated with it, these technical contacts are given write access to Vault and can manage secrets within a ProjectSet's two mount points (nonprod, prod).
 
 ## How to Request <a name="how-to-request"></a>
 You don’t need to request access to Vault! If you have a project set, you have at least one technical contact who can access Vault through the CLI or UI, and you have a Kubernetes Service Account associated with your project set's Vault Mount Points in each namespace environment. (dev, test, prod, and tools).

--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -71,7 +71,7 @@ These organizations permanently store teams' private repositories with closed-so
 * Each ministry team must purchase their own [user licenses](/github-enterprise-user-licenses-bc-government/) to use the organization.
 * Only ministry GitHub administrators can create repositories in this organization. Consult with your ministry's Information Management Branch (IMB) to get in touch with the GitHub administrators.
 
-![Diagram of the BC Goverment GitHub organizations](../../images/github-organization-chart.png)
+![Diagram of the BC Government GitHub organizations](../../images/github-organization-chart.png)
 
 ### Security Insights for GitHub Enterprise-linked organizations
 

--- a/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
+++ b/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
@@ -33,7 +33,7 @@ For more information on our GitHub organizations and their uses, see [B.C. gover
 
 ## Benefits of a GitHub Enterprise user licence<a name="benefits"></a>
 
-The enterprise user licence offers various features over the Free and Teams version. To find out more on the differences in featuress and pricing, see [Pricing](https://github.com/pricing).
+The enterprise user licence offers various features over the Free and Teams version. To find out more on the differences in features and pricing, see [Pricing](https://github.com/pricing).
 
 ## Enterprise account ownership<a name="ownership"></a>
 


### PR DESCRIPTION
These errors were surfaced by a run of [SiteInspector](https://github.com/siteinspector/siteinspector).

- Typos (86839f8d884a32899d8a6992e3bdaf0e93a4e64c)
- Old format Rocket.Chat URLs pointing to `pathfinder` subdomain are updated to point to `developer` subdomain (beadbc5c997a214c816cf91daeb248419400dc8e)
- Reference to the platform as a "pathfinder" environment is remove (c4c575617bae3da960a9eef5a67ac4a21db8d0dc)
- Remove a rewrite sources link that points to a document in this repository that no longer exists (86df8ff87fbb40b998aefe04769eb299e41dd950)
- Append `mailto:` to email link (d15c2b8381959e75dc812efd723bcbb87dc85b49)
- Fix Archeobot links (873093ac5570bbe7b9aff475f139465cfc72e95b)
- Fix Sysdig documentation links (bb2486548cd779827fa7e0ec3dbdcd9bfaa493b7)