### PR TITLE
404 page and robots.txt

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,8 @@ http {
     error_log  /tmp/error.log;
     access_log /tmp/access.log;
 
+    error_page 404 /404.html;
+
     location / {
       root /usr/share/nginx/html;
       try_files $uri $uri/ =404;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,14 +1,49 @@
-import * as React from "react";
+import React, { useEffect, useState } from "react";
+import { Link } from "gatsby";
 
 import Layout from "../components/layout";
 import Seo from "../components/seo";
 
-const NotFoundPage = ({ location }) => (
-  <Layout location={location}>
-    <Seo title="404: Not found" />
-    <h1>404: Not Found</h1>
-    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-  </Layout>
-);
+const NotFoundPage = ({ location }) => {
+  const [pathname, setPathname] = useState("");
+  useEffect(() => {
+    setPathname(location.pathname);
+  }, [location]);
+
+  /**
+   * Generate a useful search page path based on the path that caused the 404.
+   * /, -, _, and any whitespace characters are replaced with spaces before
+   * trimming and URI-encoding.
+   * @returns {string} Search page path
+   */
+  function getSearchPath() {
+    return (
+      "/search/?q=" + encodeURI(pathname.replace(/([\/-_\s])/g, " ").trim())
+    );
+  }
+
+  return (
+    <Layout location={location}>
+      <Seo
+        title="404: Not found"
+        meta={[{ name: "robots", content: "noindex" }]} // 404 pages should be excluded from public search engines
+      />
+      <main>
+        <h1>404: Not Found</h1>
+        <p>Hmmm, it seems like we don't have a page like:</p>
+        <pre>{pathname}</pre>
+        <p>Why not try:</p>
+        <ul>
+          <li>
+            A <Link to={getSearchPath()}>search for something similar</Link>
+          </li>
+          <li>
+            <Link to={"/"}>Home</Link>
+          </li>
+        </ul>
+      </main>
+    </Layout>
+  );
+};
 
 export default NotFoundPage;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://beta-docs.developer.gov.bc.ca/sitemap/sitemap-index.xml


### PR DESCRIPTION
This pull request adds a basic [robots.txt](https://developer.mozilla.org/en-US/docs/Glossary/Robots.txt) which allows all routes and points to the production sitemap. (f5d52a3043122b3d3cece4e5bdcdaaf3f4e2b8b7)

The Gatsby 404 page is updated with logic to suggest a search the user could try based on the path they attempted to access. (12ce2c85f281781d57874d9baa75c5ecc8717586)

<img width="1840" alt="Updated Gatsby 404 page" src="https://user-images.githubusercontent.com/25143706/177435290-694babe8-eb17-470c-83c1-84217ea95aa9.png">

The `./nginx.conf` configuration file is updated to use this 404 file in production, rather than the unstyled nginx 404 page that is being served now. 

<img width="1840" alt="Current production nginx 404 page" src="https://user-images.githubusercontent.com/25143706/177435322-336710ab-010e-484a-a3d9-999e9765e21f.png">

