### PR TITLE
Fix 404 search path regex

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -18,7 +18,7 @@ const NotFoundPage = ({ location }) => {
    */
   function getSearchPath() {
     return (
-      "/search/?q=" + encodeURI(pathname.replace(/([\/-_\s])/g, " ").trim())
+      "/search/?q=" + encodeURI(pathname.replace(/([\/_-\s])/g, " ").trim())
     );
   }
 


### PR DESCRIPTION
This replaces the 404 page's regular expression `/([\/-_\s])/g` with `/([\/_-\s])/g`. The first one will create a range from the `/` character to `_` rather than including `-` in the set.

Without this, dashes don't get stripped from incoming path. They get encoded and sent to the search page, creating a search query that doesn't work as well as it should. Ex: `ci-cd-pipelines` vs `ci cd pipelines`.