### PR TITLE
Handle Navigation menu screen resize

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -61,6 +61,10 @@ const StyledSkipNavContent = styled(SkipNavContent)`
   main {
     flex-grow: 1;
     margin: 30px;
+
+    @media (max-width: 767.98px) {
+      margin: 15px;
+    }
   }
 `;
 

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { graphql, Link, StaticQuery } from "gatsby";
 import PropTypes from "prop-types";
 import { useMediaQuery } from "react-responsive";
@@ -168,6 +168,12 @@ export default function Navigation({ location }) {
   const isSmallScreen = useMediaQuery({ query: "(max-width: 767.98px)" });
   const [isOpen, setIsOpen] = useState(!isSmallScreen);
   const path = location.pathname;
+
+  // Handle window resizing so that someone moving from a small screen
+  // with the menu closed will see the menu on a wide screen
+  useEffect(() => {
+    if (!isSmallScreen) setIsOpen(true);
+  }, [isSmallScreen]);
 
   return (
     <>

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -156,6 +156,7 @@ const StyledDiv = styled.div`
     box-shadow: 1px 1px 3px rgb(0 0 0 / 10%);
     width: 100%;
     min-width: 100%;
+    padding: 15px;
   }
 
   nav > ul {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -18,7 +18,7 @@ const NotFoundPage = ({ location }) => {
    */
   function getSearchPath() {
     return (
-      "/search/?q=" + encodeURI(pathname.replace(/([\/_-\s])/g, " ").trim())
+      "/search/?q=" + encodeURI(pathname.replace(/([/_-\s])/g, " ").trim())
     );
   }
 


### PR DESCRIPTION
This pull request adds logic to the Navigation menu component so that if a user closes the menu on a narrow window, the menu automatically shows if they resize the window to a wide size (5fb151b1c917455b75a97970b9d2135388bf7aa1). Without this change, it's possible to close the menu, resize the window, and then have no visible Navigation menu or any affordance to re-open it.

Additionally, the white space around page content and the Navigation menu is decreased on mobile to improve the amount of text that can appear on one line. (3b6bbef8006fb05575b45b798efc9c6a9402bbef)

Before, on iPhone 4 sized screen:
<img width="430" alt="Original white space on iPhone 4" src="https://user-images.githubusercontent.com/25143706/177892579-274aabfb-a57a-4532-a146-d245d9606684.png">

After:
<img width="430" alt="New white space on iPhone 4" src="https://user-images.githubusercontent.com/25143706/177892588-c66b6387-93d7-4558-b1be-61a6831e87c8.png">

Also included, an unnecessary escape character is removed from the 404 page regex, which quiets an `eslint` warning. (4b82127e86ed7f3d0a63de656f05450d2a2451d8) 