### PR TITLE
Search result getItemPath() link function handles index page

### DIFF
--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -50,8 +50,10 @@ const StyledListItem = styled.li`
 const Result = ({ item }) => {
   // This split assumes that item.link is a full URL (not a partial path)
   // and that we are serving the site from a sub-domain (not a sub-directory)
+  // Ex: https://beta-docs.developer.gov.bc.ca/ -> /
+  //     https://beta-docs.developer.gov.bc.ca/login-to-openshift/ -> /login-to-openshift/
   function getItemPath(item) {
-    return `/${item.link.split("/")[3]}/`;
+    return `/${item.link.split("/").slice(3).join("/")}`;
   }
 
   return (


### PR DESCRIPTION
This pull request updates the Search page <Result> component to handle links to the homepage. Prior to this change, the link would be created pointing to `//` which would throw this error:

<img width="1728" alt="Search result page showing console error" src="https://user-images.githubusercontent.com/25143706/178345819-ffb0af64-c4ad-4d13-83f8-ee6e7aba7d3a.png">

After this change, the link points to / as expected:
<img width="1840" alt="Search result page showing link to localhost index" src="https://user-images.githubusercontent.com/25143706/178345974-0d6dd7c8-f01e-423c-91fa-1eaa4ca7b399.png">
