### PR TITLE
Update WordPress URL references

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,4 +1,4 @@
 GATSBY_GOOGLE_CUSTOM_SEARCH_API_KEY=
 GATSBY_GOOGLE_SEARCH_ENGINE_ID=
 GATSBY_GOOGLE_SITE_VERIFICATION=
-GATSBY_WORDPRESS_SITE_BASE_URL=https://platform-services-dev.apps.silver.devops.gov.bc.ca
+GATSBY_WORDPRESS_SITE_BASE_URL=https://cloud-test.apps.silver.devops.gov.bc.ca

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,4 +1,4 @@
 GATSBY_GOOGLE_CUSTOM_SEARCH_API_KEY=
 GATSBY_GOOGLE_SEARCH_ENGINE_ID=
 GATSBY_GOOGLE_SITE_VERIFICATION=
-GATSBY_WORDPRESS_SITE_BASE_URL=https://platform-services-dev.apps.silver.devops.gov.bc.ca
+GATSBY_WORDPRESS_SITE_BASE_URL=https://cloud-test.apps.silver.devops.gov.bc.ca

--- a/src/docs/app-monitoring/sysdig-monitor-onboarding.md
+++ b/src/docs/app-monitoring/sysdig-monitor-onboarding.md
@@ -45,7 +45,7 @@ Related links:
 - [Sysdig Monitor](https://sysdig.com/products/monitor/)
 - [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 - [Sysdig API](https://docs.sysdig.com/en/docs/developer-tools/sysdig-rest-api-conventions/)
-- [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/)
+- [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/private-cloud/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/)
 - [Sydig User Profile](https://app.sysdigcloud.com/#/settings/user)
 - [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
 

--- a/src/docs/app-monitoring/sysdig-monitor-setup-team.md
+++ b/src/docs/app-monitoring/sysdig-monitor-setup-team.md
@@ -24,7 +24,7 @@ sort_order: 2
 
 The Sysdig Teams Operator runs in the cluster and enables a team to create and manage access to a dedicated Sysdig Team account for BC Gov Private Cloud PaaS users. The team is scoped to the OpenShift namespaces that belong to the team. Sysdig also provides a default dashboard to identify system [resources, limits and actual usage](/openshift-project-resource-quotas/).
 
-For more information on Sysdig Monitor, see [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/).
+For more information on Sysdig Monitor, see [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/private-cloud/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/).
 
 ## On this page
 - [Sign in to Sysdig](#sign-in-sysdig)
@@ -183,7 +183,7 @@ Related links:
 - [Sysdig Monitor](https://sysdig.com/products/monitor/)
 - [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 - [Sysdig API](https://docs.sysdig.com/en/docs/developer-tools/sysdig-rest-api-conventions/)
-- [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/)
+- [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/private-cloud/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/)
 - [Sydig User Profile](https://app.sysdigcloud.com/#/settings/user)
 - [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
 

--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -53,7 +53,7 @@ The `bcgov` organization contains all public code repositories that hold open-so
 The `bcgov-c` organization stores temporary (up to 12 months), private repositories with closed-source code and private documents. Closed-source projects must be moved to the `bcgov` organization at the end of the 12 months. This repository is **private**.
 
 * Use this repository if you need a temporary location for code while you collect approvals to make the code public. You must commit to making the code public in the future in order to use this repository.
-* Only the Platform Services team can create repositories in this organization. You can ask them to create a repository by [submitting a request to Platform Services Team](%WORDPRESS_BASE_URL%/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/#request-a-new-github-user-access-for-bcgovc-private-org-or-to-create-a-private-repository/).
+* Only the Platform Services team can create repositories in this organization. You can ask them to create a repository by [submitting a request to Platform Services Team](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/#request-a-new-github-user-access-for-bcgovc-private-org-or-to-create-a-private-repository/).
 
 Your product team can only have a **permanent**, private repository in `bcgov-c` if it is a GitOps repository with ArgoCD manifests. We strongly discourage creating permanent, private repositories in this organization.
 
@@ -85,7 +85,7 @@ Related links:
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [GitHub Enterprise user licences in the BC government](/github-enterprise-user-licenses-bc-government/)
 * [Remove a user's BCGov GitHub access](/remove-user-bcgov-github-access/)
-* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
+* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
+++ b/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
@@ -40,7 +40,7 @@ GitHub User Access Removal Request:
 Related links:
 * [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [BC Government organizations in GitHub](/bc-government-organizations-in-github/)
-* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
+* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
 
 Rewrite sources:
 * https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/github/README.md

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -94,7 +94,7 @@ const IndexPage = ({ location }) => {
             <p>
               Read about{" "}
               <a
-                href={`${WORDPRESS_BASE_URL}/support-and-community/platform-training-and-resources/`}
+                href={`${WORDPRESS_BASE_URL}/private-cloud/support-and-community/platform-training-and-resources/`}
               >
                 the free training
               </a>{" "}

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -85,7 +85,7 @@ Make sure that the link to an external page is descriptive. The user should know
 
 When linking from one Markdown page in the `./src/docs/` folder to another, write the link in the form `/<slug of the target page>/`. While these links won't work when viewing the page on GitHub, they will work on the Gatsby site.
 
-When linking from Markdown pages in `./src/docs/` to the Private Cloud PaaS WordPress site, use the token `%WORDPRESS_BASE_URL%` in place of the site address and before the path of the document being linked to, in the form `%WORDPRESS_BASE_URL%/path-to-page/`. This is to allow for different WordPress URLs to be injected depending on the environment. 
+When linking from Markdown pages in `./src/docs/` to the Cloud WordPress site, use the token `%WORDPRESS_BASE_URL%` in place of the site address and before the path of the document being linked to, in the form `%WORDPRESS_BASE_URL%/path-to-page/`. This is to allow for different WordPress URLs to be injected depending on the environment. 
 
 ### FAQs
 [Don't write FAQs](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/faqs) or format sections as a question and answer. Just tell the reader what they need to know.


### PR DESCRIPTION
This pull request updates references to the Cloud WordPress site.

Initially, our WordPress site references pointed to a single site `dev` instance for the Private Cloud site only: `https://platform-services-dev.apps.silver.devops.gov.bc.ca/`

Now, we will point to a multi-site `test` instance that will host Private Cloud, Public Cloud, and SaaS sub-sites: `https://cloud-test.apps.silver.devops.gov.bc.ca/`

I've updated the `.env` environment variable example files to reference the root (parent) site in the multi-site instance (97db06f332dff912b31fc63c1fa771e54c8294bb). This allows us to link to the Private Cloud, Public Cloud, and SaaS sites as needed.

As a result of this update, our base URL structure changes slightly when pointing to the Private Cloud sub-site. I have updated all existing references to ensure the links work and point to the multi-site `test` instance. (3aba1b4c3a92e6664800dafbdafc7bc5e7911344)

Lastly, I've updated the Tech Docs Writing Guide to reference "Cloud WordPress" as opposed to "Private Cloud WordPress". (75924be2049857c63ea23c435d5af936d00e0e55)
