### PR TITLE
Replace react-helmet with Gatsby Head component for SEO

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
     description: `Documentation for the BC Government's Private Cloud as a Service Platform.`,
     author: `@bcgov`,
     siteUrl: `https://beta-docs.developer.gov.bc.ca/`,
+    googleSiteVerification: `${process.env.GATSBY_GOOGLE_SITE_VERIFICATION}`,
   },
   trailingSlash: `always`,
   plugins: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,7 +12,6 @@ module.exports = {
   },
   trailingSlash: `always`,
   plugins: [
-    `gatsby-plugin-react-helmet`,
     `gatsby-plugin-react-svg`,
     `gatsby-plugin-image`,
     `gatsby-plugin-sharp`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,6 @@ module.exports = {
   siteMetadata: {
     title: `Private Cloud as a Service Platform Technical Documentation`,
     description: `Documentation for the BC Government's Private Cloud as a Service Platform.`,
-    author: `@bcgov`,
     siteUrl: `https://beta-docs.developer.gov.bc.ca/`,
     googleSiteVerification: `${process.env.GATSBY_GOOGLE_SITE_VERIFICATION}`,
   },

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,7 @@
+/**
+ * See: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/
+ */
+
+exports.onRenderBody = ({ setHtmlAttributes }) => {
+  setHtmlAttributes({ lang: "en" });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "gatsby-plugin-catch-links": "^4.19.0",
         "gatsby-plugin-image": "^2.19.0",
         "gatsby-plugin-manifest": "^4.19.0",
-        "gatsby-plugin-react-helmet": "^5.19.0",
         "gatsby-plugin-react-svg": "^3.1.0",
         "gatsby-plugin-sharp": "^4.19.0",
         "gatsby-plugin-sitemap": "^5.19.0",
@@ -11569,21 +11568,6 @@
         "gatsby": "^4.0.0-next"
       }
     },
-    "node_modules/gatsby-plugin-react-helmet": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.19.0.tgz",
-      "integrity": "sha512-XXrJYfHqoaUe57oAF+/ljPHncrvYk0UonES3aUwynbWsR8UXhQpdbwqIOYZPGQgPsc1X55Kzdo+/3pU1gA9ajQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^4.0.0-next",
-        "react-helmet": "^5.1.3 || ^6.0.0"
-      }
-    },
     "node_modules/gatsby-plugin-react-svg": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-svg/-/gatsby-plugin-react-svg-3.1.0.tgz",
@@ -19981,27 +19965,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "peer": true
-    },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
@@ -20048,15 +20011,6 @@
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-side-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/react-test-renderer": {
@@ -32727,14 +32681,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "gatsby-plugin-react-helmet": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.19.0.tgz",
-      "integrity": "sha512-XXrJYfHqoaUe57oAF+/ljPHncrvYk0UonES3aUwynbWsR8UXhQpdbwqIOYZPGQgPsc1X55Kzdo+/3pU1gA9ajQ==",
-      "requires": {
-        "@babel/runtime": "^7.15.4"
-      }
-    },
     "gatsby-plugin-react-svg": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-svg/-/gatsby-plugin-react-svg-3.1.0.tgz",
@@ -38789,24 +38735,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "peer": true
-    },
-    "react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "peer": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      }
-    },
     "react-is": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
@@ -38842,13 +38770,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "react-side-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "peer": true,
-      "requires": {}
     },
     "react-test-renderer": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gatsby-plugin-catch-links": "^4.19.0",
     "gatsby-plugin-image": "^2.19.0",
     "gatsby-plugin-manifest": "^4.19.0",
-    "gatsby-plugin-react-helmet": "^5.19.0",
     "gatsby-plugin-react-svg": "^3.1.0",
     "gatsby-plugin-sharp": "^4.19.0",
     "gatsby-plugin-sitemap": "^5.19.0",

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -7,7 +7,6 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { useStaticQuery, graphql } from "gatsby";
 import { SkipNavLink, SkipNavContent } from "@reach/skip-nav";
 import styled from "styled-components";
 
@@ -15,6 +14,8 @@ import Header from "./header";
 import Navigation from "./navigation";
 import Footer from "./footer";
 import FontStyles from "./font-styles";
+
+import { useSiteMetadata } from "../hooks/useSiteMetadata";
 
 import "./layout.css";
 import "@reach/skip-nav/styles.css";
@@ -69,21 +70,13 @@ const StyledSkipNavContent = styled(SkipNavContent)`
 `;
 
 const Layout = ({ children, location }) => {
-  const data = useStaticQuery(graphql`
-    query SiteTitleQuery {
-      site {
-        siteMetadata {
-          title
-        }
-      }
-    }
-  `);
+  const { title } = useSiteMetadata();
 
   return (
     <Page>
       <FontStyles />
       <StyledSkipNavLink>Skip to main content</StyledSkipNavLink>
-      <Header siteTitle={data.site.siteMetadata?.title || `Title`} />
+      <Header siteTitle={title || `Title`} />
       <FlexContainer>
         <Navigation location={location} />
         <StyledSkipNavContent>{children}</StyledSkipNavContent>

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -1,94 +1,47 @@
 /**
- * SEO component that queries for data with
- *  Gatsby's useStaticQuery React hook
- *
- * See: https://www.gatsbyjs.com/docs/use-static-query/
+ * Search Engine Optimization component for providing page metadata
+ * See: https://www.gatsbyjs.com/docs/how-to/adding-common-features/adding-seo-component/
  */
 
 import * as React from "react";
 import PropTypes from "prop-types";
-import { Helmet } from "react-helmet";
-import { useStaticQuery, graphql } from "gatsby";
 
-function Seo({ description, lang, meta, title }) {
-  const { site } = useStaticQuery(
-    graphql`
-      query {
-        site {
-          siteMetadata {
-            title
-            description
-            author
-          }
-        }
-      }
-    `
-  );
+import { useSiteMetadata } from "../hooks/useSiteMetadata";
 
-  const metaDescription = description || site.siteMetadata.description;
-  const defaultTitle = site.siteMetadata?.title;
-  const GOOGLE_SITE_VERIFICATION = process.env.GATSBY_GOOGLE_SITE_VERIFICATION;
+function Seo({ description, title, pathname, children }) {
+  const {
+    title: defaultTitle,
+    description: defaultDescription,
+    siteUrl,
+    googleSiteVerification,
+  } = useSiteMetadata();
+
+  const seo = {
+    title: `${title} | ${defaultTitle}` || defaultTitle,
+    description: description || defaultDescription,
+    url: `${siteUrl}${pathname || ""}`,
+    googleSiteVerification: googleSiteVerification || "",
+  };
 
   return (
-    <Helmet
-      htmlAttributes={{
-        lang,
-      }}
-      title={title}
-      titleTemplate={defaultTitle ? `%s | ${defaultTitle}` : null}
-      meta={[
-        {
-          name: `description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.siteMetadata?.author || ``,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: metaDescription,
-        },
-        {
-          name: `google-site-verification`,
-          content: GOOGLE_SITE_VERIFICATION,
-        },
-      ].concat(meta)}
-    />
+    <>
+      <title>{seo.title}</title>
+      <meta name="description" content={seo.description} />
+      <meta property="og:title" content={seo.title} />
+      <meta property="og:description" content={seo.description} />
+      <meta property="og:type" content="website" />
+      <meta
+        name="google-site-verification"
+        content={seo.googleSiteVerification}
+      />
+      {children}
+    </>
   );
 }
 
-Seo.defaultProps = {
-  lang: `en`,
-  meta: [],
-  description: ``,
-};
-
 Seo.propTypes = {
   description: PropTypes.string,
-  lang: PropTypes.string,
-  meta: PropTypes.arrayOf(PropTypes.object),
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 };
 
 export default Seo;

--- a/src/hooks/useSearchParams.js
+++ b/src/hooks/useSearchParams.js
@@ -1,0 +1,11 @@
+/**
+ * Hook for accessing search parameters after checking for `window`
+ * See: https://www.gatsbyjs.com/docs/debugging-html-builds/#how-to-check-if-window-is-defined
+ */
+
+export const useSearchParams = () => {
+  const isBrowser = typeof window !== "undefined";
+  const params = new URLSearchParams(isBrowser ? window.location.search : null);
+
+  return params;
+};

--- a/src/hooks/useSiteMetadata.js
+++ b/src/hooks/useSiteMetadata.js
@@ -1,0 +1,23 @@
+/**
+ * Hook for querying data in components via GraphQL
+ * See: https://www.gatsbyjs.com/docs/how-to/querying-data/use-static-query/
+ */
+
+import { graphql, useStaticQuery } from "gatsby";
+
+export const useSiteMetadata = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          title
+          description
+          siteUrl
+          googleSiteVerification
+        }
+      }
+    }
+  `);
+
+  return data.site.siteMetadata;
+};

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -24,10 +24,6 @@ const NotFoundPage = ({ location }) => {
 
   return (
     <Layout location={location}>
-      <Seo
-        title="404: Not found"
-        meta={[{ name: "robots", content: "noindex" }]} // 404 pages should be excluded from public search engines
-      />
       <main>
         <h1>404: Not Found</h1>
         <p>Hmmm, it seems like we don't have a page like:</p>
@@ -47,3 +43,12 @@ const NotFoundPage = ({ location }) => {
 };
 
 export default NotFoundPage;
+
+export const Head = () => {
+  return (
+    <Seo title="404: Not Found">
+      {/* 404 pages should be excluded from public search engines */}
+      <meta name="robots" content="noindex" />
+    </Seo>
+  );
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,11 @@
 import * as React from "react";
-import { graphql, Link, useStaticQuery } from "gatsby";
+import { Link } from "gatsby";
 import styled from "styled-components";
 
 import Layout from "../components/layout";
 import Seo from "../components/seo";
+
+import { useSiteMetadata } from "../hooks/useSiteMetadata";
 
 const WORDPRESS_BASE_URL = process.env.GATSBY_WORDPRESS_SITE_BASE_URL;
 
@@ -36,21 +38,13 @@ const Card = styled.div`
 `;
 
 const IndexPage = ({ location }) => {
-  const data = useStaticQuery(graphql`
-    query IndexSiteTitleQuery {
-      site {
-        siteMetadata {
-          title
-        }
-      }
-    }
-  `);
+  const { title } = useSiteMetadata();
 
   return (
     <Layout location={location}>
       <Seo title="Home" />
       <main>
-        <h1>Welcome to the {data.site.siteMetadata.title || `Title`}</h1>
+        <h1>Welcome to the {title || `Title`}</h1>
         <Grid className="col-2">
           <Card>
             <h2>Get Started</h2>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -42,7 +42,6 @@ const IndexPage = ({ location }) => {
 
   return (
     <Layout location={location}>
-      <Seo title="Home" />
       <main>
         <h1>Welcome to the {title || `Title`}</h1>
         <Grid className="col-2">
@@ -276,3 +275,7 @@ const IndexPage = ({ location }) => {
 };
 
 export default IndexPage;
+
+export const Head = () => {
+  return <Seo title="Home" />;
+};

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -10,6 +10,8 @@ import LoadSpinnerGroup from "../components/load-spinner";
 import Pagination from "../components/pagination";
 import Seo from "../components/seo";
 
+import { useSearchParams } from "../hooks/useSearchParams";
+
 const StyledListItem = styled.li`
   a {
     color: #313132;
@@ -85,10 +87,8 @@ const SearchPage = ({ location }) => {
   const [isError, setIsError] = useState(false);
   const [results, setResults] = useState({});
 
-  // Query params
-  const params = new URLSearchParams(
-    typeof window !== "undefined" ? window.location.search : null
-  );
+  // Query parameters
+  const params = useSearchParams();
   const query = params.get("q");
   const currentPage = Number(params.get("p")) || 1;
 
@@ -224,9 +224,7 @@ const SearchPage = ({ location }) => {
 export default SearchPage;
 
 export const Head = () => {
-  const query = new URLSearchParams(
-    typeof window !== "undefined" ? window.location.search : null
-  ).get("q");
+  const query = useSearchParams().get("q");
 
   return (
     <Seo title={`Search: ${query}`}>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -146,10 +146,6 @@ const SearchPage = ({ location }) => {
 
   return (
     <Layout location={location}>
-      <Seo
-        title={`Search: ${query}`}
-        meta={[{ name: "robots", content: "noindex" }]} // Search pages should be excluded from public search engines
-      />
       <main>
         <h1>Search</h1>
 
@@ -228,3 +224,16 @@ const SearchPage = ({ location }) => {
 };
 
 export default SearchPage;
+
+export const Head = () => {
+  const query = new URLSearchParams(
+    typeof window !== "undefined" ? window.location.search : null
+  ).get("q");
+
+  return (
+    <Seo title={`Search: ${query}`}>
+      {/* Search pages should be excluded from public search engines */}
+      <meta name="robots" content="noindex" />
+    </Seo>
+  );
+};

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -129,12 +129,10 @@ const SearchPage = ({ location }) => {
     axios
       .get(searchUrl)
       .then(response => {
-        console.log("response: ", response);
         setResults(response?.data);
         setIsLoading(false);
       })
       .catch(error => {
-        console.log("error: ", error);
         setIsError(true);
         setIsLoading(false);
       });

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -43,7 +43,7 @@ const StyledListItem = styled.li`
 
     @media (max-width: 767.98px) {
       div {
-        padding: 0.8em 0;
+        padding: 0.8em 0.4em;
       }
     }
   }

--- a/src/pages/{MarkdownRemark.frontmatter__slug}.js
+++ b/src/pages/{MarkdownRemark.frontmatter__slug}.js
@@ -5,22 +5,28 @@ import Layout from "../components/layout";
 import Seo from "../components/seo";
 
 export default function Template({
-  data, // injected by the GraphQL query: https://www.gatsbyjs.com/docs/working-with-images-in-markdown/#inline-images-with-gatsby-remark-images
+  data, // injected by the GraphQL pageQuery below: https://www.gatsbyjs.com/docs/how-to/routing/adding-markdown-pages/
   location, // supplied by Gatsby to top-level page components: https://www.gatsbyjs.com/docs/location-data-from-props/
 }) {
-  const { markdownRemark } = data; // data.markdownRemark holds your post data
-  const { frontmatter, html } = markdownRemark;
+  const { markdownRemark } = data;
+  const { html } = markdownRemark;
   return (
     <Layout location={location}>
-      <Seo
-        title={frontmatter?.title}
-        description={frontmatter?.description}
-        meta={[{ property: "keywords", content: frontmatter?.keywords }]}
-      />
       <main dangerouslySetInnerHTML={{ __html: html }} />
     </Layout>
   );
 }
+
+export const Head = ({ data }) => {
+  const { markdownRemark } = data;
+  const { frontmatter } = markdownRemark;
+
+  return (
+    <Seo title={frontmatter?.title} description={frontmatter?.description}>
+      <meta property="keywords" content={frontmatter?.keywords} />
+    </Seo>
+  );
+};
 
 export const pageQuery = graphql`
   query ($id: String!) {


### PR DESCRIPTION
[Gatsby v4.19 introduced the Head API](https://www.gatsbyjs.com/docs/reference/release-notes/v4.19/#gatsby-head-api) as an opinionated "right way" to add metadata to pages in Gatsby, moving away from previous solutions that used `react-helmet`. This pull request refactors the existing `react-helmet` usage (through the `gatsby-plugin-react-helmet` plugin) to use the new `<Head>` component. To the end user (and search engines), there is no appreciable difference to the site before and after this pull request, except that is should be easier to maintain and quicker to build in the future.

Also included:
- A `useSiteMetadata` hook is added (5aef6082de0cef7d1b65e435755db928970970da) to centralize accessing the site metadata
- A `useSearchParams` hook is added (fcf23df9b48cbd30857fb32e4cefc5d01adb3b22) to centralize accessing search parameters in Gatsby, where it's necessary to check for the `window` object due to SSR
- Left and right padding is added to Search page results in mobile view so they look better if a user taps and drags on them (ce4be65509be39ff89715cfd433512bc3ccafe4b)