### PR TITLE
Refactor navigation menu accordion buttons to include text label

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -17,31 +17,59 @@ const StyledListItem = styled.li`
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
+    margin: 0 -15px;
+    padding: 0 15px;
+    width: auto;
 
-    span.category-title {
-      display: inline-block;
-      font-size: 18px;
-      font-weight: 700;
-      margin-top: 8px;
-      padding: 0;
-    }
-
-    button {
-      background-color: white;
-      border: none;
-      cursor: pointer;
-      height: 44px;
-      margin-right: -15px;
-      min-width: 44px;
-
-      &:focus {
+    &:focus-within {
+      div {
         background-color: #fcba19;
         box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
         outline: none;
       }
+    }
 
-      svg {
-        width: 20px;
+    button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: flex;
+      flex-direction: row;
+      min-height: 44px;
+      padding: 0;
+      width: 100%;
+
+      &:focus {
+        outline: none;
+      }
+
+      span.category-title {
+        display: inline-block;
+        flex-grow: 1;
+        font-size: 18px;
+        font-weight: 700;
+        margin: 8px 15px 0 0;
+        padding: 0;
+        text-align: initial;
+      }
+
+      div {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-around;
+        width: 44px;
+        height: 44px;
+
+        svg {
+          width: 20px;
+        }
+      }
+    }
+
+    &:hover {
+      span.category-title {
+        text-decoration: underline;
       }
     }
   }
@@ -85,14 +113,14 @@ const NavListItem = ({ id, links, path, title }) => {
   return (
     <StyledListItem>
       <div>
-        <span className="category-title">{title}</span>
         <button
           aria-controls={id}
           aria-expanded={isOpen}
           aria-label={`${isOpen ? "Collapse" : "Expand"} ${title}`}
           onClick={() => setIsOpen(!isOpen)}
         >
-          {isOpen ? <SvgChevronUp /> : <SvgChevronDown />}
+          <span className="category-title">{title}</span>
+          <div>{isOpen ? <SvgChevronUp /> : <SvgChevronDown />}</div>
         </button>
       </div>
       <ul id={id} style={{ display: `${isOpen ? "inherit" : "none"}` }}>


### PR DESCRIPTION
This pull request refactors the navigation menu component's accordion sub-menus to make navigation easier.

Prior to this change, users would often click on the category title expecting it to open the accordion sub-menu it referred to. This behavior is natural, but I had left this functionality out because the reference design I was following ([GOV.UK Platform as a Service](https://docs.cloud.service.gov.uk/)) also opened a landing page for the category when the text was clicked. Since it appears we don't be copying this behavior, I've opted to have the accordion expand/collapse button encompass both the arrow icon and the category text.

Visually, this looks nearly identical, except that I've added a text underline on mouse-over as another affordance.

<img width="1840" alt="Screen Shot 2022-07-25 at 9 44 56 AM" src="https://user-images.githubusercontent.com/25143706/180831166-91239701-7fc9-4a83-b534-1b287ef6c96f.png">

This new markup reads the same in Chrome Vox. There is likely room for improvement in this component, as I haven't been able to test it with a regular screen reader user.