### PR TITLE
Update links to Private Cloud WordPress to use tokenized URLs

### DIFF
--- a/src/docs/openshift-projects-and-access/provision-new-openshift-project.md
+++ b/src/docs/openshift-projects-and-access/provision-new-openshift-project.md
@@ -24,7 +24,7 @@ On the OpenShift platform, different teams organize their work in isolated proje
 
 Each new request must be reviewed and approved, including requests for additional projects from teams that already have one or more projects on the platform.
 
-[Read more about project provisioning and the prerequisites](https://platform-services-dev.apps.silver.devops.gov.bc.ca/our-products-in-the-private-cloud-paas/project-registry/) or submit a project provisioning request through [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing).
+[Read more about project provisioning and the prerequisites](%WORDPRESS_BASE_URL%/private-cloud/our-products-in-the-private-cloud-paas/project-registry/) or submit a project provisioning request through [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing).
 
 ---
 

--- a/src/docs/training-and-learning/training-from-the-platform-services-team.md
+++ b/src/docs/training-and-learning/training-from-the-platform-services-team.md
@@ -26,7 +26,7 @@ The BC Gov Provate Cloud PaaS OpenShift 101 and 201 courses include a theory 'wo
 
 If the courses fill up, email PlatformServicesTeam@gov.bc.ca - preference is given to recently onboarded teams. If you’re unable to attend a training session, we will soon be offering recordings. 
 
-[Register for an OpenShift course](https://platform-services-dev.apps.silver.devops.gov.bc.ca/support-and-community/platform-training-and-resources/).
+[Register for an OpenShift course](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/platform-training-and-resources/).
  
  ## Video resources <a name="video"></a>
 


### PR DESCRIPTION
This pull request updates the "Provision a new OpenShift project" and "Training from the Platform Services team" documents to use the tokenized WordPress URL format to link to the Private Cloud WordPress site. This tokenized URL format allows us to link from a `test` namespace to a `test` namespace, `prod` to `prod`, etc. The `beta-docs.developer.gov.bc.ca` site currently points to  `https://cloud-test.apps.silver.devops.gov.bc.ca/private-cloud/`.

The hard-coded URL that was previously used referred to a single-site WordPress instance in a `dev` namespace that will be going away now that we have a multi-site WordPress network in a `test` namespace.