### PR TITLE
Add homepage link to Vault page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -138,7 +138,11 @@ const IndexPage = ({ location }) => {
             <h3>Security and privacy compliance</h3>
             <ul>
               <li>STRA and PIA for Private Cloud Platform (coming soon)</li>
-              <li>Vault Secret Managment Service (coming soon)</li>
+              <li>
+                <Link to={"/vault-secrets-management-service"}>
+                  Vault Secrets Management Service
+                </Link>
+              </li>
               <li>Artifactory Trusted Repository Service (coming soon)</li>
               <li>Security best practices for apps (coming soon)</li>
             </ul>


### PR DESCRIPTION
Replaces a "(coming soon)" placeholder with a Gatsby `<Link>` to our Vault page.

<img width="1840" alt="Homepage showing Vault link in place" src="https://user-images.githubusercontent.com/25143706/181304995-cb34aafc-01cd-4441-a8f4-05877601f62f.png">
