### PR TITLE
Update homepage links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -161,7 +161,7 @@ const IndexPage = ({ location }) => {
               </li>
               <li>
                 <a
-                  href={`${WORDPRESS_BASE_URL}/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/`}
+                  href={`${WORDPRESS_BASE_URL}/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/`}
                 >
                   Common platform requests in the BC Gov Private Cloud PaaS
                 </a>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -53,17 +53,17 @@ const IndexPage = ({ location }) => {
             </p>
             <ul>
               <li>
-                <Link to={"/provision-new-openshift-project"}>
+                <Link to={"/provision-new-openshift-project/"}>
                   Provision a new project in OpenShift
                 </Link>
               </li>
               <li>
-                <Link to={"/grant-user-access-openshift"}>
+                <Link to={"/grant-user-access-openshift/"}>
                   User access in OpenShift
                 </Link>
               </li>
               <li>
-                <Link to={"/openshift-project-resource-quotas"}>
+                <Link to={"/openshift-project-resource-quotas/"}>
                   Project resource quotas
                 </Link>
               </li>
@@ -139,7 +139,7 @@ const IndexPage = ({ location }) => {
             <ul>
               <li>STRA and PIA for Private Cloud Platform (coming soon)</li>
               <li>
-                <Link to={"/vault-secrets-management-service"}>
+                <Link to={"/vault-secrets-management-service/"}>
                   Vault Secrets Management Service
                 </Link>
               </li>
@@ -151,7 +151,7 @@ const IndexPage = ({ location }) => {
             <h3>Use GitHub in BC Gov</h3>
             <ul>
               <li>
-                <Link to={"/bc-government-organizations-in-github"}>
+                <Link to={"/bc-government-organizations-in-github/"}>
                   BC Government Organizations in Github
                 </Link>
               </li>
@@ -169,7 +169,7 @@ const IndexPage = ({ location }) => {
             <h3>Automation and resiliency</h3>
             <ul>
               <li>
-                <Link to={"/app-resiliency-guidelines"}>
+                <Link to={"/app-resiliency-guidelines/"}>
                   App resiliency guidelines
                 </Link>
               </li>
@@ -180,12 +180,12 @@ const IndexPage = ({ location }) => {
             <h3>App Monitoring</h3>
             <ul>
               <li>
-                <Link to={"/sysdig-monitor-setup-team"}>
+                <Link to={"/sysdig-monitor-setup-team/"}>
                   Set up a team in Sysdig Monitor
                 </Link>
               </li>
               <li>
-                <Link to={"/sysdig-monitor-set-up-advanced-functions"}>
+                <Link to={"/sysdig-monitor-set-up-advanced-functions/"}>
                   Set up advance functions in Sysdig Monitor
                 </Link>
               </li>
@@ -206,7 +206,7 @@ const IndexPage = ({ location }) => {
             <ul>
               <li>KeyCloak SSO (coming soon)</li>
               <li>
-                <Link to={"/reusable-services-list"}>
+                <Link to={"/reusable-services-list/"}>
                   Reusable services list
                 </Link>
               </li>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -143,7 +143,11 @@ const IndexPage = ({ location }) => {
                   Vault Secrets Management Service
                 </Link>
               </li>
-              <li>Artifactory Trusted Repository Service (coming soon)</li>
+              <li>
+                <Link to={"/image-artifact-management-with-artifactory/"}>
+                  Artifactory Trusted Repository Service
+                </Link>
+              </li>
               <li>Security best practices for apps (coming soon)</li>
             </ul>
           </Card>


### PR DESCRIPTION
- Trailing slashes are added to existing Gatsby links using the `<Link>` component. These links work without the trailing slash, but it adds a 302 redirection for Gatsby to direct to the canonical URL with the trailing slash. (a053263066b7f84205919c7f5f561aa5e57e2172)
- A link to the Artifactory page is added on the homepage (51cffc5ddc8b9b225c74e78e271d3dcad200ac8d)
- The link to the WordPress page "Common requests" is updated to support the multi-site WordPress URL format with `/private-cloud` at the base of the path. Without this update, the link is expecting the page to be relative to the site route, causing a 404. (2094c11fadf43bca7172ad4ac2b15828e3b8275e)