### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Lifecycle:Experimental](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
-This is a single location for all technical/developer documentation for product teams working on the Private Cloud Openshift Platform.
+This is a single location for all technical/developer documentation for product teams working on the Private Cloud OpenShift Platform.
+
+Visit the deployed Gatsby site at [beta-docs.developer.gov.bc.ca](https://beta-docs.developer.gov.bc.ca).
 
 ## Documentation
 

--- a/src/docs/app-monitoring/sysdig-monitor-setup-team.md
+++ b/src/docs/app-monitoring/sysdig-monitor-setup-team.md
@@ -72,7 +72,7 @@ A list of users to be added to this team.
 
   - `User Role` - These are the available roles to assign to different team members:
 
-    - `ROLE_TEAM_EDIT (Advanced User)`: Read and write access to the components of the application available to the team. Can create, edit and delete dashboards, alerts or other content. Recommended for admininstrators and team members that need to create and manage dashboards.
+    - `ROLE_TEAM_EDIT (Advanced User)`: Read and write access to the components of the application available to the team. Can create, edit and delete dashboards, alerts or other content. Recommended for administrators and team members that need to create and manage dashboards.
 
     - `ROLE_TEAM_STANDARD (Standard User)`: Same as Advanced User but without access to the **Explore** page. Recommended for developers that need to refer to dashboards for resource tuning and service monitoring.
 

--- a/src/docs/platform-architecture-reference/platform-storage.md
+++ b/src/docs/platform-architecture-reference/platform-storage.md
@@ -57,9 +57,9 @@ See the [Red Hat documentation](https://access.redhat.com/documentation/en-us/re
 
 ### S3-Compatible Object Storage (Dell EMC Elastic Cloud Storage)
 
-For applications that need to store large amounts of unstructured data we recommend using the S3-compliant on-premises [Object Store Service](https://ssbc-client.gov.bc.ca/services/ObjectStorage/overview.htm) offered by the OCIO Enterprise Hosting branch. The Object Store Service provides storage for unstructured data such as images, PDFs and other types of files. NetApp storage offered on the OpenShift 4 Platform isn't suitable for large amounts of unstructured data. NetApp storage should only be used for structured data such as databases that require high-I/O workloads.
+For applications that need to store large amounts of unstructured data we recommend using the S3-compliant on-premises [Object Store Service](https://ssbc-client.gov.bc.ca/services/ObjectStorage/overview.htm) (requires IDIR) offered by the OCIO Enterprise Hosting branch. The Object Store Service provides storage for unstructured data such as images, PDFs and other types of files using protocols including S3, NFS, and HTTP. The service is aimed at objects typically over 100 KB, updated infrequently, retained longer term, with performance response targets of 100ms or more.
 
-The OCIO has an [object store](https://ssbc-client.gov.bc.ca/services/ObjectStorage/overview.htm) service that supports the AWS S3 protocol. The service is aimed at objects typically over 100 KB, updated infrequently, retained longer term, with performance response targets of 100ms or more.
+NetApp storage offered on the OpenShift 4 Platform isn't suitable for large amounts of unstructured data. NetApp storage should only be used for structured data such as databases that require high-I/O workloads.
 
 Contact your ministry IMB to get access to the ministry service account that controls access and where a bucket for your application will be provisioned.
 

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -70,7 +70,7 @@ For more information on Backup Container, see the following pages:
 
 The BC Address Geocoder REST API lets you integrate real-time standardization, validation and geocoding of physical addresses into your applications. See [the Data Catalogue](https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service) for information on aspects of the REST API that aren't covered in the OpenAPI definition.
 
-The Geocoder helps you validate and geocode addresses (including public and related business occupants); find physical sites, intersections and occupants; and find sites, intersections and occupants near a point or within an area. The current baseUrl for the online geocoder is https://geocoder.api.gov.bc.ca/.
+The Geocoder helps you validate and geocode addresses (including public and related business occupants); find physical sites, intersections and occupants; and find sites, intersections and occupants near a point or within an area. The current baseUrl for the online geocoder is `https://geocoder.api.gov.bc.ca/`.
 
 The URL allows both public and gated access. Gated access requires an APIkey. To get a sandbox APIkey with a maximum rate of 1000 requests per minute, visit the [Geocoder API console](https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service/resource/40d6411e-ab98-4df9-a24e-67f81c45f6fa/view/1d3c42fc-53dc-4aab-ae3b-f4d056cb00e0). You can get an unrestricted APIkey for use in government applications by opening a ticket with the [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15).
 

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -79,7 +79,7 @@ For more information on the BC Address Geocoder, see the following pages:
 * [BC Address Geocoder repository](https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#outputSRS)
 
 ## Common Document Generation service<a name="dgen"></a>
-Use the Document Generation service (DGEN) to generate documents using template files that contain field values from a database. Once generated, the completed document is stored in the Document Management Service (DMS) repository where you can view and sign it with an electronic signature. You must access DGEN programmatically through the [DGEN-API](https://api.nrs.gov.bc.ca/dgen-api/). You can find a description of the API in the [Natural Resource Ministry's (NRM) API Store](https://apistore.nrs.gov.bc.ca/store/apis/info?name=dgen-api&version=v1&provider=admin).
+Use the Document Generation service (DGEN) to generate documents using template files that contain field values from a database. Once generated, the completed document is stored in the Document Management Service (DMS) repository where you can view and sign it with an electronic signature. You must access DGEN programmatically through the DGEN-API (`https://api.nrs.gov.bc.ca/dgen-api/`). You can find a description of the API in the [Natural Resource Ministry's (NRM) API Store](https://apistore.nrs.gov.bc.ca/store/apis/info?name=dgen-api&version=v1&provider=admin).
 
 ### Features
 


### PR DESCRIPTION
This PR updates content pages to fix links:

- In the Reusable Services List page, the geocoder API (431d005a8f8c9719f1a94935af1f1974596c932e) and DGEN-API (cafae347d875011830a46971662ae7ea423e75c6) base URLs get backticks to create code snippets so Gatsby doesn't turn them into links. These aren't URLs you would visit in your browser, so they shouldn't be links.
- In the Platform Storage page, the Object Store link is labeled as IDIR-required since it requires auth. The description here is re-ordered and updated for clarity. (80635c3f1254178aff09afb9475d372f207c7286)
- Typo fixed in the Sysdig Monitor Team Setup page (2e9176be96dbcb4f91c4d108272cf24a1ea83730)

Also, the production URL is added to the README (1c88be1bf7ae25a09ba21d72200a6a00f57dd98b) since it's up now.