### PR TITLE
Add links to BC Design System on DevHub

### DIFF
--- a/src/docs/design-system/about-the-design-system.md
+++ b/src/docs/design-system/about-the-design-system.md
@@ -20,7 +20,7 @@ sort_order: 1
 
 # About the design system
 
-The Platform Services design system helps developers and designers build better digital products and services. It’s a collection of digital resources and tools, including a library of reusable user interface components and design patterns. The system makes it easier and faster to build custom B.C. government websites and applications.
+The [BC Government Design System for Digital Services](https://developer.gov.bc.ca/Design-System/About-the-Design-System) helps developers and designers build better digital products and services. It’s a collection of digital resources and tools, including a library of reusable user interface components and design patterns. The system makes it easier and faster to build custom B.C. government websites and applications.
 
 ## On this page
 
@@ -60,6 +60,7 @@ You can contribute to the design system by doing any of the following:
 
 ---
 Related links:
+* [BC Design System](https://developer.gov.bc.ca/Design-System/About-the-Design-System)
 * [Joint Working Group](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/digital-delivery/web-property-process/web-property-applications)
 * [Propose a New Component](https://developer.gov.bc.ca/Design-System/Propose-a-New-Component)
 


### PR DESCRIPTION
This PR adds links from the Design System page on Tech Docs to the Design System hosted on DevHub. This content will not be moving into the Tech Docs site - it is owned outside of our team by the Government Digital Experience (GDX) team within the Ministry of Citizens' Services. The reference to the "Platform Services design system" is corrected to the full name of the BC Design System.

<img width="1840" alt="Design System page showing new link to DevHub" src="https://user-images.githubusercontent.com/25143706/182685030-3cd7656a-a138-4985-af00-750336007f14.png">
