### PR TITLE
Responsive iframe handling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -88,6 +88,7 @@ module.exports = {
               maxWidth: 1600,
             },
           },
+          `gatsby-remark-responsive-iframe`,
         ],
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "gatsby-remark-autolink-headers": "^5.19.0",
         "gatsby-remark-copy-linked-files": "^5.19.0",
         "gatsby-remark-images": "^6.19.0",
+        "gatsby-remark-responsive-iframe": "^5.20.0",
         "gatsby-source-filesystem": "^4.19.0",
         "gatsby-transformer-remark": "^5.19.0",
         "gatsby-transformer-sharp": "^4.19.0",
@@ -12016,6 +12017,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gatsby-remark-responsive-iframe": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-5.20.0.tgz",
+      "integrity": "sha512-Z0nMN4TBYLM8K9dB4m+zGfSCUW6NXdvPD18aa3nhFzQ4Geg1qTKwyC5re2QF9EZgNw1Uox6/7wWC2SkQALz+8Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "cheerio": "^1.0.0-rc.10",
+        "common-tags": "^1.8.2",
+        "lodash": "^4.17.21",
+        "unist-util-visit": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
       }
     },
     "node_modules/gatsby-script": {
@@ -32988,6 +33007,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "gatsby-remark-responsive-iframe": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-5.20.0.tgz",
+      "integrity": "sha512-Z0nMN4TBYLM8K9dB4m+zGfSCUW6NXdvPD18aa3nhFzQ4Geg1qTKwyC5re2QF9EZgNw1Uox6/7wWC2SkQALz+8Q==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "cheerio": "^1.0.0-rc.10",
+        "common-tags": "^1.8.2",
+        "lodash": "^4.17.21",
+        "unist-util-visit": "^2.0.3"
       }
     },
     "gatsby-script": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gatsby-remark-autolink-headers": "^5.19.0",
     "gatsby-remark-copy-linked-files": "^5.19.0",
     "gatsby-remark-images": "^6.19.0",
+    "gatsby-remark-responsive-iframe": "^5.20.0",
     "gatsby-source-filesystem": "^4.19.0",
     "gatsby-transformer-remark": "^5.19.0",
     "gatsby-transformer-sharp": "^4.19.0",


### PR DESCRIPTION
To support responsive `<iframe>` sizing, this PR adds the `gatsby-remark-responsive-iframe` plugin for `gatsby-transformer-remark`. This enables us to dynamically stretch `<iframe>` sizes so YouTube video embeds work as expected in Markdown documents.

Example YouTube embed code:
`<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`

Example output showing the width and height of the `<iframe>` being adjusted by the new plugin:
<img width="1840" alt="Screen Shot 2022-08-05 at 10 12 26 AM" src="https://user-images.githubusercontent.com/25143706/183129323-ba51f35e-417e-465f-8c2e-60bbf68f54f7.png">
