### PR TITLE
iFrame styling

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -66,6 +66,11 @@ const StyledSkipNavContent = styled(SkipNavContent)`
     @media (max-width: 767.98px) {
       margin: 15px;
     }
+
+    /* Wrapper div for iframes created by gatsby-remark-responsive-iframe */
+    div.gatsby-resp-iframe-wrapper {
+      margin-bottom: 1.25em;
+    }
   }
 `;
 

--- a/src/docs/training-and-learning/training-from-the-platform-services-team.md
+++ b/src/docs/training-and-learning/training-from-the-platform-services-team.md
@@ -30,7 +30,7 @@ If the courses fill up, email PlatformServicesTeam@gov.bc.ca - preference is giv
  
  ## Video resources <a name="video"></a>
 
-The videos below can also be found on this [youtube playlist](https://www.youtube.com/playlist?list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg)
+The videos below can also be found on this [YouTube playlist](https://www.youtube.com/playlist?list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 


### PR DESCRIPTION
Adds `margin-bottom` to the container for `<iframe>` elements generated by `gatsby-remark-responsive-iframe`.

<img width="1840" alt="iFrame showing lower margin" src="https://user-images.githubusercontent.com/25143706/183156684-f259d9cf-8924-4239-9bd5-70e84985a1c1.png">
