### PR TITLE
Update homepage links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -177,7 +177,11 @@ const IndexPage = ({ location }) => {
                   App resiliency guidelines
                 </Link>
               </li>
-              <li>CI/CD Pipeline automation (coming soon)</li>
+              <li>
+                <Link to={"/ci-cd-pipeline-templates/"}>
+                  CI/CD Pipeline automation
+                </Link>
+              </li>
             </ul>
           </Card>
           <Card>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -148,7 +148,11 @@ const IndexPage = ({ location }) => {
                   Artifactory Trusted Repository Service
                 </Link>
               </li>
-              <li>Security best practices for apps (coming soon)</li>
+              <li>
+                <Link to={"/security-best-practices-for-apps/"}>
+                  Security best practices for apps
+                </Link>
+              </li>
             </ul>
           </Card>
           <Card>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -200,8 +200,16 @@ const IndexPage = ({ location }) => {
           <Card>
             <h3>Database and API management</h3>
             <ul>
-              <li>Open source database technologies (coming soon)</li>
-              <li>High availability database clusters (coming soon)</li>
+              <li>
+                <Link to={"/opensource-database-technologies/"}>
+                  Open source database technologies
+                </Link>
+              </li>
+              <li>
+                <Link to={"/high-availability-database-clusters/"}>
+                  High availability database clusters
+                </Link>
+              </li>
               <li>API guidelines (coming soon)</li>
             </ul>
           </Card>


### PR DESCRIPTION
This pull request adds Gatsby `<Link>` internal links to placeholders that were on the homepage which now have corresponding content on the site.

- Database pages (bd27a5201bd36bf0726ff72febe6c77bca009fac)
- CI/CD pipeline (312cc0f26df784edb58c9cf556ddb72ea17e740d)
- Security best practices (db5e63b7857b66e86ea46cf2ebbd14d9396f9a23)

<img width="1840" alt="Homepage after new links added" src="https://user-images.githubusercontent.com/25143706/183526026-30bc1516-b6fa-41b8-bb43-219f3be130f9.png">
