### PR TITLE
Sentence case for titles and headings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
+++ b/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
@@ -18,7 +18,8 @@ content_owner: Shelly Han
 sort_order: 3
 ---
 
-# Create alerts in Sysdig Monitor
+# Create alerts and notifications in Sysdig Monitor
+
 You can create alerts based on monitoring dashboards in Sysdig Monitor, that notify your team when something needs attention.
 
 Here are some steps on how to setup the Sysdig alerts with [Rocket.Chat](https://chat.developer.gov.bc.ca/).

--- a/src/docs/app-monitoring/sysdig-monitor-onboarding.md
+++ b/src/docs/app-monitoring/sysdig-monitor-onboarding.md
@@ -26,7 +26,7 @@ tags:
 - team guide
 ---
 
-# Start monitoring with Sysdig
+# Onboarding to application monitoring with Sysdig
 
 [Sysdig Monitor](https://sysdig.com/products/monitor/) provides system-level monitoring of Kubernetes hosts and the ability to create custom dashboards, alerts and operational-level captures to diagnose application or platform-level issues.
 

--- a/src/docs/app-monitoring/sysdig-monitor-onboarding.md
+++ b/src/docs/app-monitoring/sysdig-monitor-onboarding.md
@@ -16,14 +16,6 @@ author: Shelly Han
 content_owner: Shelly Han
 
 sort_order: 1
-
-# This is to be removed when moving out of devhub
-tags:
-- Sysdig
-- monitoring
-- openshift monitoring
-- developer guide
-- team guide
 ---
 
 # Onboarding to application monitoring with Sysdig

--- a/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
+++ b/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
@@ -18,7 +18,7 @@ content_owner: Shelly Han
 sort_order: 4
 ---
 
-# Advanced Usage in Sysdig Monitor
+# Set up advanced metrics in Sysdig Monitor
 
 ## On this page
 - [Use Service Discovery to import application metrics endpoints](#sysdig-service-discovery)

--- a/src/docs/app-monitoring/sysdig-monitor-setup-team.md
+++ b/src/docs/app-monitoring/sysdig-monitor-setup-team.md
@@ -60,7 +60,7 @@ Below is a sample of the `sysdig-team` custom resource manifest.  We also provid
 
 
 **Name and Namespace:**
-The `sysdig-team` custom resource should be created in your Openshift project set `tools` namespace. Name it using the license plate number for your project set to make sure it's unique.
+The `sysdig-team` custom resource should be created in your OpenShift project set `tools` namespace. Name it using the license plate number for your project set to make sure it's unique.
 
 **Team Description:**
 Add a description for the sysdig team.

--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -155,12 +155,12 @@ The following are some fantastic examples of applications that operate on the pl
 ---
 Related links:
 * [12 Factor App](https://12factor.net/)
-* [Openshift: Compute Resources](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#dev-compute-resources)
+* [OpenShift: Compute Resources](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#dev-compute-resources)
 * [Horizontal Pod Autoscaler](https://docs.openshift.com/container-platform/3.11/dev_guide/pod_autoscaling.html)
 * [Quality of Service](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#quality-of-service-tiers)
 
 * [Pod Terminations](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
-* [Openshift 101](https://developer.gov.bc.ca/ExchangeLab-Course:-Openshift-101)
+* [OpenShift 101](https://developer.gov.bc.ca/ExchangeLab-Course:-Openshift-101)
 * [PodDisruptionBudgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
 * [Tools: BCDevOps Backup Container](https://github.com/BCDevOps/backup-container)
 * [Tools: Patroni](https://github.com/BCDevOps/platform-services/tree/master/apps/pgsql/patroni)

--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -1,5 +1,5 @@
 ---
-title: App Resiliency Guidelines
+title: Application resiliency guidelines
 
 slug: app-resiliency-guidelines
 

--- a/src/docs/automation-and-resiliency/application-resource-tuning.md
+++ b/src/docs/automation-and-resiliency/application-resource-tuning.md
@@ -1,5 +1,5 @@
 ---
-title: Application Resource Tuning  
+title: Application resource tuning
 
 slug: application-resource-tuning
 

--- a/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
+++ b/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
@@ -41,7 +41,7 @@ Any product teams working in the Silver or Gold clusters on the BC Gov Private C
 Currently, the following technologies are available to product teams:
 - [ArgoCD](https://github.com/BCDevOps/openshift-wiki/blob/b1a4e6db91932fd3f29705a5c8ee44983abf8763/docs/ArgoCD/argocd_info.md)
 - [GitHub Actions](https://github.com/bcgov/security-pipeline-templates/tree/main/.github/workflows)
-- [Openshift Pipelines (Tekton)](https://github.com/bcgov/security-pipeline-templates/tree/main/tekton)
+- [OpenShift Pipelines (Tekton)](https://github.com/bcgov/security-pipeline-templates/tree/main/tekton)
 
 While Jenkins is technically supported on the platform, the Platform Services team highly discourages teams from using this technology as it's inefficient with the use of valuable platform resources. Over the next few months we'll be guiding the teams that currently use Jenkins to transition to a more modern and efficient technology.
 

--- a/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
+++ b/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
@@ -49,7 +49,7 @@ While Jenkins is technically supported on the platform, the Platform Services te
 
 Each team should make the final decision on which technology they want to use and may depend on their experience and comfort with each tool. The Platform Services team recommends the following, depending on your team's level of experience:
 
-- If your team has limited experience with automation pipelines, the combination of Github Actions for builds and ArgoCD for deployments.
+- If your team has limited experience with automation pipelines, the combination of GitHub Actions for builds and ArgoCD for deployments.
 
 - For more mature teams with previous automation experience, OpenShift Pipelines is a good choice.
 

--- a/src/docs/automation-and-resiliency/prepare-to-load-test-application-on-openshift.md
+++ b/src/docs/automation-and-resiliency/prepare-to-load-test-application-on-openshift.md
@@ -18,7 +18,7 @@ content_owner: Cailey Jones
 sort_order: 7
 ---
 
-# Prepare to load test an application in OpenShift
+# Prepare to load test an application on OpenShift
 Follow these guidelines to load test ministry applications hosted in the Silver and Gold cluster of the OpenShift 4 platform.
 
 ## Load testing requirements

--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -90,7 +90,7 @@ Related links:
 * [Application Resource Tuning](https://github.com/BCDevOps/developer-experience/blob/master/docs/resource-tuning-recommendations.md)
 * [Get Started with Sysdig Monitoring](https://developer.gov.bc.ca/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring)
 * [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
-* [Openshift 4 Project Registry](https://registry.developer.gov.bc.ca/public-landing)
+* [OpenShift 4 Project Registry](https://registry.developer.gov.bc.ca/public-landing)
 * [OpenShift project resource quotas](/openshift-project-resource-quotas/)
 * [S3 Object Storage Service](https://github.com/BCDevOps/OpenShift4-Migration/issues/59)
 

--- a/src/docs/build-deploy-and-maintain-apps/build-with-rhel-base-images.md
+++ b/src/docs/build-deploy-and-maintain-apps/build-with-rhel-base-images.md
@@ -101,6 +101,7 @@ RUN INSTALL_PKGS="space separated list of packages" && \
 ```
 
 ---
+
 Related links:
 
 - [OCP 4.9 Docs - Adding subscription entitlements as a build secret](https://docs.openshift.com/container-platform/4.9/cicd/builds/running-entitled-builds.html#builds-source-secrets-entitlements_running-entitled-builds)

--- a/src/docs/build-deploy-and-maintain-apps/build-with-rhel-base-images.md
+++ b/src/docs/build-deploy-and-maintain-apps/build-with-rhel-base-images.md
@@ -1,5 +1,5 @@
 ---
-title: Build with RHEL Base Images
+title: Build with RHEL base images
 
 slug: build-with-rhel-base-images
 
@@ -18,7 +18,7 @@ content_owner: Matt Spencer
 sort_order: 10
 ---
 
-# Build with RHEL Base Images
+# Build with RHEL base images
 
 If you wish to use a [Red Hat Enterprise Linux (RHEL)](https://catalog.redhat.com/software/containers/search?p=1&architecture=amd64&vendor_name=Red%20Hat%7CRed%20Hat%2C%20Inc.) based image to build upon, you will need to take some extra steps to get access to the RHEL Subscription included in the OpenShift Platform.
 

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
@@ -1,5 +1,5 @@
 ---
-title: Setup an Artifactory project and repository
+title: Set up an Artifactory project and repository
 
 slug: setup-artifactory-project-repository
 

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
@@ -1,5 +1,5 @@
 ---
-title: Setup an Artifactory service account
+title: Set up an Artifactory service account
 
 slug: setup-artifactory-service-account
 
@@ -18,7 +18,7 @@ content_owner: Cailey Jones
 sort_order: 9
 ---
 
-# Setup an Artifactory service account
+# Set up an Artifactory service account
 
 Artifactory access is controlled through Artifactory service accounts. Service accounts are meant to be shared by teams and used by automation tools like pipelines.
 

--- a/src/docs/database-and-api-management/database-backup-best-practices.md
+++ b/src/docs/database-and-api-management/database-backup-best-practices.md
@@ -1,5 +1,5 @@
 ---
-title: Database Backup Best Practices
+title: Database backup best practices
 
 slug: database-backup-best-practices
 
@@ -18,7 +18,7 @@ content_owner: Cailey Jones
 sort_order: 3
 ---
 
-# Database Backup Best Practices
+# Database backup best practices
 
 If something bad happens to your database, you will want to recover your application's data quickly, easily, and with up-to-date data. With that goal in mind, your data recovery plan should include these three considerations:
 

--- a/src/docs/database-and-api-management/database-backup-best-practices.md
+++ b/src/docs/database-and-api-management/database-backup-best-practices.md
@@ -30,13 +30,13 @@ Don't forget: **Automate Everything!** You should automate every part of your da
 
 Once you've set up your recovery plan, you can apply it using one of the many [automated backup solutions](#automated-backup-solutions) popular on the platform. Remember that you are not required to use the ones listed here. If it suits your needs to use something else or to create your own, feel free! But remember: it's easier to ask for help if there are lots of other people using the same tool!
 
-## Database Backup Basics
+## Database backup basics
 
 Before we dig into the details of how to create and implement your data recovery plan, we should discuss a few terms and basics.
 
 For a quick introduction to databases in general, check out our [Open-Source Database Technologies](/opensource-database-technologies/) document. This is a great spot to get a more detailed introduction to some database-specific terminology.
 
-### Database Dumps
+### Database dumps
 
 Every major DBMS (database management software) comes with a **backup utility tool**. You can find the documentation for the most common DBMSes on the OpenShift Platform below:
 * Postgres: [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html)
@@ -47,13 +47,13 @@ Running one of these tools will produce a file (usually called a "database dump"
 
 You _must_ use these utility tools for your backups. Don't try to backup your database by saving the datafiles directly. If you do, your data may become corrupted. Any trusted backup automation tool (including those mentioned in this document) will use these utility tools.
 
-### Backup Types
+### Backup types
 
 A **complete backup** is a backup file which contains everything required for a database to be recovered completely from scratch. These are larger than other types of backup, but they're more reliable because they don't depend on anything but a single dump file to work.
 
 A **delta backup** is a record of changes to the database since the last backup. Delta backups are smaller than complete backups. If you need to recover your database with a delta backup file, you'll need the most recent complete backup _and_ all of the delta backups that have taken place since. Deltas are a great way to reduce backup storage requirements. They're also very reliable as long as you can ensure the availability of the other files that would be necessary to restore your database.
 
-## Backing Up Your Data
+## Backing up your data
 
 This first part of your data recovery plan should answer the following questions:
 
@@ -120,7 +120,7 @@ The second problem can remain hidden until you need the dump file. By then, it's
 
 Both the backup and recovery test should send notifications to your team. The Platform Team recommends that you send notifications of both successes and failures. That way, if some failure prevents a notification from being sent, you can still tell there's a problem. Most teams set up a Rocketchat webhook to recieve the status information of both the backup and recovery processes. Teams usually set up the webhook to post these messages to a private channel for the team.
 
-## Recovering Your Data
+## Recovering your data
 
 This second part of your data recovery plan should answer the following questions:
 
@@ -149,7 +149,7 @@ Your team should outline the full recovery process with special focus on those s
 
 Your team should schedule regular tests for each of the recovery procedures you develop.
 
-## Monitoring Your Database
+## Monitoring your database
 
 The best way to ensure the integrity of your data is to prevent problems from occurring in the first place. Monitoring your database status can help you to prevent issues that might otherwise require database recovery.
 
@@ -166,7 +166,7 @@ Keep in mind:
 * many DBMS will prevent your database from starting if the storage is too full. This is to prevent data corruption. You should set your threshold well below this point for your DBMS. For Patroni, this is 90%, so we recommend a threshold of 80 or below.
 * if you are close to the maximum quota for your namespace, you may not be able to increase your storage space or CPU/memory to prevent failure while you investigate the root cause. Set your thresholds accordingly.
 
-## Automated Backup Solutions
+## Automated backup solutions
 
 So now you have an idea of what you hope to accomplish with your backup and recovery process. How do you implement this plan? There are many requirements, and building your own automation for all of this seems like a lot of work.
 
@@ -192,7 +192,7 @@ The recovery plan questions at a glance:
 * **What does the recovery process look like?** The built-in recovery process only recovers the dump file into an empty database. If you wish to use point-in-time recovery, your team will need to build appropriate automation for that. You will also need to cover any additional considerations for connecting your application to your recovered database or the recreation of other necessary objects.
 * **How will your database be monitored?** Your team will need to set up their own monitoring.
 
-### CrunchyDB Operator
+### CrunchyDB operator
 
 The CrunchyDB operator allows teams to set up a Postgres database quickly and easily, and includes functionality for automating both backup and recovery. If your team is using the CrunchyDB operator, you should use this option. If your team is not using the operator to run your database, this option is not available.
 

--- a/src/docs/database-and-api-management/database-backup-best-practices.md
+++ b/src/docs/database-and-api-management/database-backup-best-practices.md
@@ -38,7 +38,7 @@ For a quick introduction to databases in general, check out our [Open-Source Dat
 
 ### Database Dumps
 
-Every major DBMS (database management software) comes with a **backup utility tool**. You can find the documentation for the most common DBMSes on the Openshift Platform below:
+Every major DBMS (database management software) comes with a **backup utility tool**. You can find the documentation for the most common DBMSes on the OpenShift Platform below:
 * Postgres: [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html)
 * MongoDB: [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/)
 * MySQL: [mysqldump](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html)

--- a/src/docs/database-and-api-management/high-availability-database-clusters.md
+++ b/src/docs/database-and-api-management/high-availability-database-clusters.md
@@ -1,5 +1,5 @@
 ---
-title: High Availability Database Clusters
+title: High availability database clusters
 
 slug: high-availability-database-clusters
 
@@ -18,7 +18,7 @@ content_owner: Cailey Jones
 sort_order: 1
 ---
 
-# High Availability Database Clusters
+# High availability database clusters
 
 Your database must be highly available (HA) to run well on the OpenShift Platform.
 

--- a/src/docs/database-and-api-management/high-availability-database-clusters.md
+++ b/src/docs/database-and-api-management/high-availability-database-clusters.md
@@ -26,7 +26,7 @@ The platform has a very high uptime. Maintenance can take place without requirin
 
 But, you must design your applications to take advantage of this high up-time. For databases, this means that they *must* be highly-available. If you try to run a database that is not highly-available, your database may suffer outages and data corruption even more often than it would on traditional infrastructure.
 
-## Database Basics
+## Database basics
 
 Before we talk a little more about highly-available databases, we should cover some key information about databases in general and common terms that you'll see both in these documents and in database-related documentation elsewhere.
 
@@ -34,7 +34,7 @@ Before we talk a little more about highly-available databases, we should cover s
 
 **Database High Availability Manager** (or DB HA Manager) refers to the software that allows your database to be highly-available. Sometimes, the DB HA Manager is built-in to the DBMS: MongoDB has a built-in DB HA Manager. In other cases, the DB HA Manager is separate: for example, both Patroni and the CrunchyDB Operator are DB HA Managers for Postgres. 
 
-## Highly-Available Databases are Different
+## Highly-available databases are different
 
 A typical highly-available deployment has 3+ pods. All the pods are running the same application. Traffic can connect to any one of them, and they all share the same storage. If any pod goes down, the other two are there to run the application while another pod spins up to replace the one that failed. It doesn't matter which pod is which, because they're all doing the same stateless things.
 
@@ -49,7 +49,7 @@ So, what does this mean for your software architecture?
 * The primary instance will have more load than the secondary instances. Since any member of the cluster can be elected as primary, you need provide all instances with enough compute resources to act as the primary instance.
 * Your application must be able to handle connecting to a new instance at any time.
 
-## High Availability Database Options
+## High availability database options
 
 For information on open-source and free options for highly-available database software, check out our [Open-Source Database Technologies](/opensource-database-technologies/) documentation.
 

--- a/src/docs/database-and-api-management/opensource-database-technologies.md
+++ b/src/docs/database-and-api-management/opensource-database-technologies.md
@@ -1,5 +1,5 @@
 ---
-title: Open-Source Database Technologies
+title: Open-source database technologies
 
 slug: opensource-database-technologies
 
@@ -18,7 +18,7 @@ content_owner: Cailey Jones
 sort_order: 2
 ---
 
-# Open-Source Database Technologies
+# Open-source database technologies
 
 If you haven't yet taken a look at our [High Availability Database Clusters](/high-availability-database-clusters/) documentation, we recommend you check that out first. It contains an outline of how databases work on the OpenShift platform and why it's important to use highly-available databases. All the technologies discussed here are highly-available.
 ## Postgres

--- a/src/docs/database-and-api-management/opensource-database-technologies.md
+++ b/src/docs/database-and-api-management/opensource-database-technologies.md
@@ -33,7 +33,7 @@ Postgres is a [relational database](https://insightsoftware.com/blog/whats-the-d
 
 ## MongoDB
 
-[MongoDB](https://www.mongodb.com/) is the next most common database. It has built-in HA capabilities, and you can find an [example of how to deploy a Mongo replica set on Github](https://github.com/bcgov/mongodb-replicaset-container). 
+[MongoDB](https://www.mongodb.com/) is the next most common database. It has built-in HA capabilities, and you can find an [example of how to deploy a Mongo replica set on GitHub](https://github.com/bcgov/mongodb-replicaset-container). 
 
 MongoDB is a [non-relational database](https://insightsoftware.com/blog/whats-the-difference-relational-vs-non-relational-databases/). If a relational database would better suit your application's needs, consider [Postgres](#postgres) instead.
 

--- a/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
+++ b/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
@@ -64,7 +64,7 @@ To get a list of the users who have access to a namespace, and in what role, a p
 ```
 oc get rolebindings
 ```
-For more information on adding users, you can watch [Using Just Ask! to gain access into the BCGov or BCDevops Github Organizations](https://www.youtube.com/watch?v=IvdPyx2-qm0) or use [the Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/).
+For more information on adding users, you can watch [Using Just Ask! to gain access into the BCGov or BCDevops GitHub Organizations](https://www.youtube.com/watch?v=IvdPyx2-qm0) or use [the Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/).
 
 ## Request platform access<a name="request-access"></a>
 
@@ -83,9 +83,9 @@ Follow these best practices when you grant namespace access to a user:
 
 ---
 Related links:
-* [BC Government organizations in Github](/bc-government-organizations-in-github/)
+* [BC Government organizations in GitHub](/bc-government-organizations-in-github/)
 * [Provision a new project set](/provision-new-openshift-project/)
-* [Using Just Ask! to gain access into the BCGov or BCDevops Github Organizations](https://www.youtube.com/watch?v=IvdPyx2-qm0)
+* [Using Just Ask! to gain access into the BCGov or BCDevops GitHub Organizations](https://www.youtube.com/watch?v=IvdPyx2-qm0)
 * [Add someone to the BC Government GitHub Org](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/)
 * [Using RBAC to define and apply permissions](https://docs.openshift.com/container-platform/4.9/authentication/using-rbac.html)
 

--- a/src/docs/openshift-projects-and-access/login-to-openshift.md
+++ b/src/docs/openshift-projects-and-access/login-to-openshift.md
@@ -1,5 +1,5 @@
 ---
-title: Login to OpenShift
+title: Log in to OpenShift
 
 slug: login-to-openshift
 

--- a/src/docs/openshift-projects-and-access/login-to-openshift.md
+++ b/src/docs/openshift-projects-and-access/login-to-openshift.md
@@ -24,7 +24,7 @@ Teams can log in to OpenShift with either a GitHub ID or IDIR. IDIR authenticati
 
 You have to log in with IDIR into the OpenShift console before you can associate any role bindings with the IDIR account.
 
-When you log in to the Silver cluster Openshift console, you have the option of using GitHub or your Azure AD IDIR.
+When you log in to the Silver cluster OpenShift console, you have the option of using GitHub or your Azure AD IDIR.
 
 ![Image of authorization options](https://user-images.githubusercontent.com/53879638/146621070-6d473a3d-289c-400e-86a7-947732441fac.png)
 

--- a/src/docs/platform-architecture-reference/set-up-tcp-connectivity-on-private-cloud-openshift-platform.md
+++ b/src/docs/platform-architecture-reference/set-up-tcp-connectivity-on-private-cloud-openshift-platform.md
@@ -18,7 +18,7 @@ content_owner: Ian Watts
 sort_order: 4
 ---
 
-# Set up TCP connectivity on OpenShift
+# Set up TCP connectivity on the Private Cloud OpenShift Platform
 Use this page to learn how to configure direct [transmission control protocol (TCP)](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) access to services on the BC Gov Private Cloud PaaS using the Porter Operator.
 
 ## On this page

--- a/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
+++ b/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
@@ -29,7 +29,7 @@ You should take particular care to adhere to security and privacy requirements w
 - [Secure Coding Guideline](#secure-coding-guideline)
 - [Application Security Self-Assessment](#application-security-self-assessment)
 
-## Open Development Basics 
+## Open development basics
 
 There is a [healthy debate](http://www.dwheeler.com/secure-programs/Secure-Programs-HOWTO/open-source-security.html) in the security community around the use and development of operation support system (OSS) applications and the implications of exposing the code publicly versus keeping it behind closed doors. The debate boils down to the fact that there is no conclusive evidence that deems either open or closed source as inherently more secure. It all comes down to the people (the coders) and their willingness to build security into their code. The one thing that coding in the open does for security is that the public scrutiny of a coders work is proven as a motivating factor for "doing it right" from the start.
 

--- a/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
+++ b/src/docs/security-and-privacy-compliance/security-best-practices-for-apps.md
@@ -1,5 +1,5 @@
 ---
-title: Security Best Practices For Apps
+title: Security best practices for apps
 
 slug: security-best-practices-for-apps
 
@@ -17,7 +17,7 @@ content_owner: Nick Corcoran
 ---
 <!-- Draft in progress -->
 
-# Security best practices for applications
+# Security best practices for apps
 
 You should take particular care to adhere to security and privacy requirements when working on content in an open environment such as GitHub. The Office of the Chief Information Officer (OCIO) provides the IM/IT Standards you are required to follow, and the content you work with on GitHub must conform with the requirements of being labeled as "Public" using the OCIO Information Security Classification Framework.
 

--- a/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
+++ b/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
@@ -1,5 +1,5 @@
 ---
-title: Vault Secrets Management
+title: Vault secrets management
 
 slug: vault-secrets-management-service
 
@@ -16,7 +16,7 @@ author: Matt Spencer
 content_owner: Cailey Jones
 ---
 
-# Vault Secrets Management
+# Vault secrets management
 
 The B.C. government Vault Secrets Management tool, based on the HashiCorp Vault product, provides a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, or certificates. Vault provides a unified interface to any secret, while providing tight access control and recording a detailed audit log.
 

--- a/src/docs/training-and-learning/training-external-resources.md
+++ b/src/docs/training-and-learning/training-external-resources.md
@@ -3,11 +3,11 @@ title: External training resources
 
 slug: training-external-resources 
 
-description: Contains links to Openshift 101 resources that come from outside of the BC Government
+description: Contains links to OpenShift 101 resources that come from outside of the BC Government
 
 keywords: training, links, resources, openshift, onboarding
 
-page_purpose: To provide materials to aid building an understanding of Openshift and give additional context to other training 
+page_purpose: To provide materials to aid building an understanding of OpenShift and give additional context to other training 
 
 audience: developer, technical lead, product owner
 
@@ -23,7 +23,7 @@ The resources below are from sources outside of the B.C. government. They provid
 
 ## Websites:
 
-[What is RedHat Openshift?](https://cloud.redhat.com/learn/what-is-openshift) - by RedHat
+[What is RedHat OpenShift?](https://cloud.redhat.com/learn/what-is-openshift) - by RedHat
 
 [OpenShift Documentation](https://docs.openshift.com/container-platform/) - by RedHat
 

--- a/src/docs/training-and-learning/training-external-resources.md
+++ b/src/docs/training-and-learning/training-external-resources.md
@@ -1,5 +1,5 @@
 ---
-title: External Training Resources
+title: External training resources
 
 slug: training-external-resources 
 

--- a/src/docs/training-and-learning/training-from-the-platform-services-team.md
+++ b/src/docs/training-and-learning/training-from-the-platform-services-team.md
@@ -20,7 +20,7 @@ sort_order: 1
 # Training from the Platform Services team
 Learning how to build in OpenShift can be hard. We’ve put together a number of resources to help.
 
-## Openshift 101 and 201 <a name="openshift101201"></a>
+## OpenShift 101 and 201 <a name="openshift101201"></a>
 
 The BC Gov Provate Cloud PaaS OpenShift 101 and 201 courses include a theory 'workshop' component, and a practical series of 'lab exercises'. OpenShift 101 is recommended for all new teams joining the platform. OpenShift 201 is a more advanced course for platform users who want to advance their skills in OpenShift.
 
@@ -56,17 +56,17 @@ The videos below can also be found on this [YouTube playlist](https://www.youtub
 
  - [Horizontal Pod Autoscaling and Vertical Pod Autoscaling for Resource Management In OpenShift](https://youtu.be/nZMtJRQR3jY)
  
- - [App Migration from Openshift On-prem to ARO](https://youtu.be/i-auqEUcR5U)
+ - [App Migration from OpenShift On-prem to ARO](https://youtu.be/i-auqEUcR5U)
 
  - [Reusable Front-End REACT and Vue Component Library for BC Gov Web Apps](https://www.youtube.com/watch?v=eFi5QJo2hgo&list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg&index=2&t=21s)
 
  - [Four Golden Signals for App Monitoring](https://youtu.be/W9xM5rd9CaQ)
 
-- [Namespace provisioning in Openshift 4 using GitOps approach](https://youtu.be/5aSon_DVbRM) 
+- [Namespace provisioning in OpenShift 4 using GitOps approach](https://youtu.be/5aSon_DVbRM) 
 
-- [Openshift 4 Platform – New Project Registry Demo](https://youtu.be/HiHsd-Rg57E)
+- [OpenShift 4 Platform – New Project Registry Demo](https://youtu.be/HiHsd-Rg57E)
 
-- [Integrating with KeyCloak SSO and BC Services Card on Openshift](https://youtu.be/IGONgJkvwms)
+- [Integrating with KeyCloak SSO and BC Services Card on OpenShift](https://youtu.be/IGONgJkvwms)
 
 - [Using BC Service Card Self Service Onboarding Application](https://youtu.be/H2tKvOQ8x4k) 
 

--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -18,7 +18,7 @@ content_owner: Olena Mitovska
 sort_order: 1
 ---
 
-# B.C. government organizations in Github
+# BC Government organizations in Github
 
 BC Gov Private Cloud PaaS product teams use <a href="https://github.com" target="_blank">GitHub</a> to host open code and repositories. Using GitHub you can:
 * Share and control code versions

--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -1,5 +1,5 @@
 ---
-title: BC Government organizations in Github
+title: BC Government organizations in GitHub
 
 slug: bc-government-organizations-in-github
 
@@ -18,7 +18,7 @@ content_owner: Olena Mitovska
 sort_order: 1
 ---
 
-# BC Government organizations in Github
+# BC Government organizations in GitHub
 
 BC Gov Private Cloud PaaS product teams use <a href="https://github.com" target="_blank">GitHub</a> to host open code and repositories. Using GitHub you can:
 * Share and control code versions
@@ -27,7 +27,7 @@ BC Gov Private Cloud PaaS product teams use <a href="https://github.com" target=
 * Collaborate with the open-source community
 * Integrate automation tools
 
-The main organization the B.C. government owns in Github is [bcgov](https://github.com/bcgov) where we store all open-source code developed by B.C. government teams. The `bcgov` organization includes close to 1000 repositories maintained by the B.C. government developer community.
+The main organization the B.C. government owns in GitHub is [bcgov](https://github.com/bcgov) where we store all open-source code developed by B.C. government teams. The `bcgov` organization includes close to 1000 repositories maintained by the B.C. government developer community.
 
 ## On this page
 - [Working in the open](#work-in-open)

--- a/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
+++ b/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
@@ -5,7 +5,7 @@ slug: github-enterprise-user-licenses-bc-government
 
 description: Describes the benefits of GitHub Enterprise user licences and how to access them.
 
-keywords: GitHub, Github Enterprise, closed source, private repository, private organization, licence, license, user licence, user license
+keywords: GitHub, GitHub Enterprise, closed source, private repository, private organization, licence, license, user licence, user license
 
 page_purpose: Discusses why you might want to use a GitHub Enterprise user licence and how to request, access, and pay for the users.
 

--- a/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
+++ b/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
@@ -18,7 +18,7 @@ content_owner: Olena Mitovska
 sort_order: 4
 ---
 
-# GitHub Enterprise user licences in the B.C. government
+# GitHub Enterprise user licences in the BC government
 
 All code by B.C. government teams should be open source by default. If you have closed-source code and still want to use GitHub, you can work temporarily in a private repository under the GitHub Enterprise licence.
 

--- a/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
+++ b/src/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
@@ -18,7 +18,7 @@ content_owner: Olena Mitovska
 sort_order: 2
 ---
 
-# Remove a user's BC Gov GitHub access
+# Remove a user's BCGov GitHub access
 
 When a user no longer needs access to a repository, the product owner or administrator of the repository must remove the user. They also have to request removal of their access from the organization by using the [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/).
 

--- a/src/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
+++ b/src/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
@@ -18,7 +18,7 @@ content_owner: Shelly Han
 sort_order: 8
 ---
 
-# Start working in the BC Gov GitHub organization
+# Start working in the BCGov GitHub organization
 
 If you plan to share code developed by or for the B.C. government, [evaluate the content](/evaluate-open-source-content/) and get approval from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -46,7 +46,7 @@ const IndexPage = ({ location }) => {
         <h1>Welcome to the {title || `Title`}</h1>
         <Grid className="col-2">
           <Card>
-            <h2>Get Started</h2>
+            <h2>Get started</h2>
             <p>
               Start here for the first steps on working in our OpenShift
               environment.
@@ -70,7 +70,7 @@ const IndexPage = ({ location }) => {
             </ul>
           </Card>
           <Card>
-            <h2>Build, Deploy and Maintain Apps</h2>
+            <h2>Build, deploy and maintain apps</h2>
             <p>Best practices on the platform.</p>
             <ul>
               <li>Build an application (coming soon)</li>
@@ -80,10 +80,10 @@ const IndexPage = ({ location }) => {
             </ul>
           </Card>
         </Grid>
-        <h2>Training and Learning</h2>
+        <h2>Training and learning</h2>
         <Grid className="col-3">
           <Card>
-            <h3>Free OpenShift Training</h3>
+            <h3>Free OpenShift training</h3>
             <p>
               Read about{" "}
               <a
@@ -140,12 +140,12 @@ const IndexPage = ({ location }) => {
               <li>STRA and PIA for Private Cloud Platform (coming soon)</li>
               <li>
                 <Link to={"/vault-secrets-management-service/"}>
-                  Vault Secrets Management Service
+                  Vault secrets management service
                 </Link>
               </li>
               <li>
                 <Link to={"/image-artifact-management-with-artifactory/"}>
-                  Artifactory Trusted Repository Service
+                  Artifactory trusted repository service
                 </Link>
               </li>
               <li>
@@ -160,7 +160,7 @@ const IndexPage = ({ location }) => {
             <ul>
               <li>
                 <Link to={"/bc-government-organizations-in-github/"}>
-                  BC Government Organizations in Github
+                  BC Government organizations in GitHub
                 </Link>
               </li>
               <li>
@@ -183,13 +183,13 @@ const IndexPage = ({ location }) => {
               </li>
               <li>
                 <Link to={"/ci-cd-pipeline-templates/"}>
-                  CI/CD Pipeline automation
+                  CI/CD pipeline automation
                 </Link>
               </li>
             </ul>
           </Card>
           <Card>
-            <h3>App Monitoring</h3>
+            <h3>App monitoring</h3>
             <ul>
               <li>
                 <Link to={"/sysdig-monitor-setup-team/"}>
@@ -202,7 +202,7 @@ const IndexPage = ({ location }) => {
                 </Link>
               </li>
               <li>Four gold signals for app monitoring (coming soon)</li>
-              <li>App Logging (coming soon)</li>
+              <li>App logging (coming soon)</li>
             </ul>
           </Card>
           <Card>
@@ -252,7 +252,7 @@ const IndexPage = ({ location }) => {
         <h2>Get support on the platform</h2>
         <Grid className="col-3">
           <Card>
-            <h3>Report a Platform Incident</h3>
+            <h3>Report a platform incident</h3>
             <p>
               If you think an incident has occurred with our services, you can
               report it by{" "}
@@ -265,7 +265,7 @@ const IndexPage = ({ location }) => {
             </p>
           </Card>
           <Card>
-            <h3>Get Help or Support</h3>
+            <h3>Get help or support</h3>
             <p>
               We follow a community-based support model. You can use our
               self-serve resources or ask for help from the platform community.{" "}
@@ -278,7 +278,7 @@ const IndexPage = ({ location }) => {
             </p>
           </Card>
           <Card>
-            <h3>DevOps Requests</h3>
+            <h3>DevOps requests</h3>
             <p>
               Not sure where to go to get things done on the platform? We've
               outlined common platform tasks and links to additional

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -97,6 +97,8 @@ Use a descriptive and specific title. What does the reader do with the page? Wha
 
 Good titles help with findability and usability.
 
+[Use sentence case](https://www2.gov.bc.ca/gov/content?id=8E987979EA6842D7BDE3EDEEA9331787#case) for titles and headings.
+
 ### Images
 Use images sparingly. If you need to use images, make sure they are supplementary to the writing. Don't rely on them to explain a process.
 


### PR DESCRIPTION
This pull request normalizes our use of sentence casing for titles and headings across all the pages of the site. Prior to this, we had been using sentence casing the majority of the time, but with title casing thrown in at random by different authors. I've added a rule to the writing guide (562c9e417cee7f323884ab32224c5dab18fd0161) to make this case requirement clear going forward. This change brings us in line with the [Web Style Guide's guidance on writing headings and page titles](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/headings#case).

This change is most obvious when viewing the site's homepage:

Left: original, right: after using sentence casing
<img width="1728" alt="Tech Docs homepage before and after" src="https://user-images.githubusercontent.com/25143706/183785347-ee4cf334-c745-40e5-a205-ba03413a82c0.png">

Also included in this PR:
- a new `.gitattributes` file to enforce LF line endings (ce81870acf507412edd281b62922a20a2c475103)
- "Build with RHEL base images" page is updated to use LF line endings instead of CRLF
- Consistent use of capitalization in "GitHub" across the project (0eba1ea69061dfcb1ece7069b1c9be26a12cd082)
- Consistent use of captialization in "OpenShift" across the project (39ab9264ef809a37ab5b81b4b05155289e72c2d4)