### PR TITLE
SSO content in Reusable Services page

### DIFF
--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -31,6 +31,7 @@ Find details on the following services or tools you can use as part of your proj
 - [go-crond](#go-crond)
 - [Matomo OpenShift](#matomo-openshift)
 - [OWASP ZAP Security Vulnerability Scanning](#owasp-zap)
+- [Pathfinder Single Sign On (SSO) Keycloak](#pathfinder-sso)  
 - [SonarQube in Private Cloud PaaS](#sq-private-cloud)
 - [SonarQube on OpenShift](#sq-openshift)
 - [WeasyPrint HTML to PDF/PNG](#weasyprint)
@@ -130,6 +131,18 @@ Matomo OpenShift provides a set of OpenShift configurations to set up an instanc
 The OWASP Zed Attack Proxy (ZAP) automatically finds security vulnerabilities in web applications. For more information, see the following pages:
 * [OWASP ZAP Security Vulnerability Scanning](https://developer.gov.bc.ca/Developer-Toy-Box/OWASP-ZAP-Security-Vulnerability-Scanning)
 * [openshift-components](https://github.com/BCDevOps/openshift-components/tree/master/cicd/jenkins-slave-zap)
+
+
+
+## Pathfinder Single Sign On Keycloak<a name="pathfinder-sso"></a>
+The Pathfinder Single Sign (SSO) on team provides the Common Hosted Sigle Sign On (CSS) App. This is a self-service app that allows you to integrate with BC goverment approved login services (identity providers).
+
+The Pathfinder SSO service is build on the foundations of Keycloak /Redhat SSO.
+
+* [Request an integration](https://bcgov.github.io/sso-requests/)
+* [An overview of our CSS App](https://github.com/bcgov/sso-keycloak/wiki)
+* [What is Keycloak (our take) ](https://github.com/bcgov/sso-keycloak/wiki/What-is-Keycloak-@-BC-Government%3F)
+* [Additional References](https://github.com/bcgov/sso-keycloak/wiki/Useful-References)
 
 ## SonarQube in the BC Gov Private Cloud PaaS<a name="sq-private-cloud"></a>
 

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -31,7 +31,7 @@ Find details on the following services or tools you can use as part of your proj
 - [go-crond](#go-crond)
 - [Matomo OpenShift](#matomo-openshift)
 - [OWASP ZAP Security Vulnerability Scanning](#owasp-zap)
-- [Pathfinder Single Sign On (SSO) Keycloak](#pathfinder-sso)  
+- [Pathfinder Single Sign-On (SSO) Keycloak](#pathfinder-single-sign-on-keycloak)
 - [SonarQube in Private Cloud PaaS](#sq-private-cloud)
 - [SonarQube on OpenShift](#sq-openshift)
 - [WeasyPrint HTML to PDF/PNG](#weasyprint)
@@ -132,7 +132,8 @@ The OWASP Zed Attack Proxy (ZAP) automatically finds security vulnerabilities in
 * [OWASP ZAP Security Vulnerability Scanning](https://developer.gov.bc.ca/Developer-Toy-Box/OWASP-ZAP-Security-Vulnerability-Scanning)
 * [openshift-components](https://github.com/BCDevOps/openshift-components/tree/master/cicd/jenkins-slave-zap)
 
-## Pathfinder Single Sign On Keycloak<a name="pathfinder-sso"></a>
+## Pathfinder Single Sign On Keycloak
+
 The Pathfinder Single Sign-On (SSO) team provides the Common Hosted Single Sign-On (CSS) App. This is a self-service app that allows you to integrate with BC government approved login services (identity providers).
 
 The Pathfinder SSO service is built on the foundations of Keycloak/Redhat SSO.

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -132,17 +132,15 @@ The OWASP Zed Attack Proxy (ZAP) automatically finds security vulnerabilities in
 * [OWASP ZAP Security Vulnerability Scanning](https://developer.gov.bc.ca/Developer-Toy-Box/OWASP-ZAP-Security-Vulnerability-Scanning)
 * [openshift-components](https://github.com/BCDevOps/openshift-components/tree/master/cicd/jenkins-slave-zap)
 
-
-
 ## Pathfinder Single Sign On Keycloak<a name="pathfinder-sso"></a>
-The Pathfinder Single Sign (SSO) on team provides the Common Hosted Sigle Sign On (CSS) App. This is a self-service app that allows you to integrate with BC goverment approved login services (identity providers).
+The Pathfinder Single Sign-On (SSO) team provides the Common Hosted Single Sign-On (CSS) App. This is a self-service app that allows you to integrate with BC government approved login services (identity providers).
 
-The Pathfinder SSO service is build on the foundations of Keycloak /Redhat SSO.
+The Pathfinder SSO service is built on the foundations of Keycloak/Redhat SSO.
 
 * [Request an integration](https://bcgov.github.io/sso-requests/)
 * [An overview of our CSS App](https://github.com/bcgov/sso-keycloak/wiki)
-* [What is Keycloak (our take) ](https://github.com/bcgov/sso-keycloak/wiki/What-is-Keycloak-@-BC-Government%3F)
-* [Additional References](https://github.com/bcgov/sso-keycloak/wiki/Useful-References)
+* [What is Keycloak (our take)](https://github.com/bcgov/sso-keycloak/wiki/What-is-Keycloak-@-BC-Government%3F)
+* [Additional references](https://github.com/bcgov/sso-keycloak/wiki/Useful-References)
 
 ## SonarQube in the BC Gov Private Cloud PaaS<a name="sq-private-cloud"></a>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -224,7 +224,15 @@ const IndexPage = ({ location }) => {
           <Card>
             <h3>Reusable code and services</h3>
             <ul>
-              <li>[Pathfinder SSO KeyCloak](https://github.com/bcgov/sso-keycloak/wiki/What-is-Keycloak-@-BC-Government%3F)</li>
+              <li>
+                <Link
+                  to={
+                    "/reusable-services-list/#pathfinder-single-sign-on-keycloak"
+                  }
+                >
+                  Pathfinder SSO Keycloak
+                </Link>
+              </li>
               <li>
                 <Link to={"/reusable-services-list/"}>
                   Reusable services list


### PR DESCRIPTION
This PR adds content from pull request #110. I'm adding this new pull request as I'm unable to make additions directly to the forked branch.

My additions:

- On the homepage, links can't be created with Markdown formatting, so I've changed the link to a Gatsby internal `<Link>` component, and I've updated the link target to point to the new SSO section in the [Reusable services list](http://localhost:8000/reusable-services-list/)  (77fc125f2c6bc7b41ff165844056a96fb7a98a49)

<img width="1840" alt="Homepage SSO link showing link target on hover" src="https://user-images.githubusercontent.com/25143706/186279414-e3be7eaa-ce52-4024-b46e-3b26d124bf3f.png">

- In creating the new link from the homepage, I discovered that our manual `<a>` anchor tags at the end of heading lines are causing Gatsby to generate IDs with lots of cruft in them. I've added an issue to look at this problem, #113. In the meantime, I've updated this particular table of contents link to point to the heading ID auto-generated by GitHub and Gatsby, which is the same in this case. (c0cfb5fd50af4e498289dec375eada7cc80b0bef)

- Fixed typos in new SSO section (14041a08bd429d28c553986e53f66611e5d4de72). I've confirmed all the new links in this section work as expected.

<img width="1840" alt="New SSO section of Reusable Services List page" src="https://user-images.githubusercontent.com/25143706/186279570-787fb484-1154-4566-ae97-125730f517d8.png">
