### PR TITLE
Fix dash in SSO Keycloak heading

### DIFF
--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -132,7 +132,7 @@ The OWASP Zed Attack Proxy (ZAP) automatically finds security vulnerabilities in
 * [OWASP ZAP Security Vulnerability Scanning](https://developer.gov.bc.ca/Developer-Toy-Box/OWASP-ZAP-Security-Vulnerability-Scanning)
 * [openshift-components](https://github.com/BCDevOps/openshift-components/tree/master/cicd/jenkins-slave-zap)
 
-## Pathfinder Single Sign On Keycloak
+## Pathfinder Single Sign-On Keycloak
 
 The Pathfinder Single Sign-On (SSO) team provides the Common Hosted Single Sign-On (CSS) App. This is a self-service app that allows you to integrate with BC government approved login services (identity providers).
 


### PR DESCRIPTION
Per #113, this dash character appears to make no difference in either Gatsby or GitHub when the heading ID is generated. Both keep the dash (effectively treating it as whitespace).