### PR TITLE
Content/remove manual heading anchors

### DIFF
--- a/src/docs/app-monitoring/check-application-health-after-outage.md
+++ b/src/docs/app-monitoring/check-application-health-after-outage.md
@@ -110,7 +110,7 @@ assignees: caggles, ShellyXueHan
 - [ ] MongoDB pods are up, running, communicating with each other and with the application.
 ## Routes
 - [ ] Is Rocketchat Prod available through it's normal route?
-- [ ] Fix route to re-point to the production instance if we've swapped over to the maintenace instance during this outage.
+- [ ] Fix route to re-point to the production instance if we've swapped over to the maintenance instance during this outage.
 ## Backups
 - [ ] Manually run the recovery test script to make sure that the most recent backup is working.
 - [ ] Ensure that next scheduled backup occurs as expected.

--- a/src/docs/app-monitoring/check-application-health-after-outage.md
+++ b/src/docs/app-monitoring/check-application-health-after-outage.md
@@ -25,13 +25,13 @@ The OpenShift platform provides a reduced chance of significant unexpected outag
 Still, it's always possible that an outage affects the platform and brings down the applications hosted there. If this happens, speedy recovery is important. Use these guidelines to ensure your application recovers quickly and effectively.
 
 ## On this page
-- [Check reporting channels](#check-channels)
-- [Check your application](#check-application)
-- [Keep track of recovery steps](#keep-track)
+- [Check reporting channels](#check-reporting-channels)
+- [Check your application](#check-your-application)
+- [Keep track of recovery steps](#keep-track-of-recovery-steps)
 
 These guidelines assume that you built your application in a cloud-native, highly resilient manner that makes effective use of the strengths of the OpenShift platform. Make sure you follow our [application resiliency guidelines](https://developer.gov.bc.ca/Developer-Tools/Resiliency-Guidelines). If your application is not cloud-native in its design, it won't benefit from the higher adaptability and recoverability of the platform and may need additional work to recover from a large outage.
 
-## Check reporting channels<a name="check-channels"></a>
+## Check reporting channels
 
 If there is a platform-wide outage, check the following sources for more information:
 
@@ -41,7 +41,7 @@ If there is a platform-wide outage, check the following sources for more informa
 
 The Platform Services team keeps the community informed about the status of the outage. While the outage is in progress, there isn't much the team can do. Review the status and stay ready for the outage to end.
 
-## Check your application<a name="check-application"></a>
+## Check your application
 
 When the outage recovers, it's likely that everything recovers on its own, due to the resiliency of the applications. However, you can check the following to make sure everything is working as expected:
 
@@ -89,7 +89,7 @@ If you have problems with your pipeline installation, delete the member pods and
 
 If you're running RabbitMQ as part of your application, you may need to restart it in case the outage caused network issues.
 
-## Keep track of recovery steps<a name="keep-track"></a>
+## Keep track of recovery steps
 
 Create an issue template in GitHub for your application that details what you need to check to ensure that your application is up and running after an outage.
 

--- a/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
+++ b/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
@@ -25,12 +25,12 @@ You can create alerts based on monitoring dashboards in Sysdig Monitor, that not
 Here are some steps on how to setup the Sysdig alerts with [Rocket.Chat](https://chat.developer.gov.bc.ca/).
 
 ## On this page
-- [Create a Rocket.Chat chat channel and webhook for alert messages](#rc-channel)
-- [Create a Sysdig team notification channel](#sysdig-notification-channel)
-- [Create a Sysdig alert](#sysdig-alert)
+- [Create a Rocket.Chat chat channel and webhook for alert messages](#create-a-rocketchat-chat-channel-and-webhook-for-alert-messages)
+- [Create a Sysdig team notification channel](#create-a-sysdig-team-notification-channel)
+- [Creating an alert](#creating-an-alert)
 
 
-## Create a Rocket.Chat chat channel and webhook for alert messages<a name="rc-channel"></a>
+## Create a Rocket.Chat chat channel and webhook for alert messages
 
 Rocket.Chat requires an incoming webhook and a script to parse the data from Sysdig. Do the following:
 - Create a RC chat channel for the alert messages to arrive if there isn't one.
@@ -82,7 +82,7 @@ Here's how the webhook should look like:
 ![RC webhook config](../../images/sysdig-team-rc-alert-webhook-config.png)
 
 
-## Create a Sysdig team notification channel<a name="sysdig-notification-channel"></a>
+## Create a Sysdig team notification channel
 
 To create a Sysdig team notification channel, do the following:
 
@@ -95,7 +95,7 @@ To create a Sysdig team notification channel, do the following:
 1. Click `Save` and now you should be able to test it by clicking on the kebab menu icon and `Test Channel`.
 
 
-## Creating an Alert<a name="sysdig-alert"></a>
+## Creating an Alert
 
 It's recommended to create alerts from an application monitoring metrics, which helps to define good alerting thresholds.
 

--- a/src/docs/app-monitoring/sysdig-monitor-onboarding.md
+++ b/src/docs/app-monitoring/sysdig-monitor-onboarding.md
@@ -26,8 +26,8 @@ sort_order: 1
 ### Here are the documents for you to follow through:
 
 1. [Set up a team in Sysdig Monitor](/sysdig-monitor-setup-team/)
-1. [Create alerts for metrics](/sysdig-monitor-create-alert-channels/)
-1. [Advanced usage in Sysdig Monitor](/sysdig-monitor-set-up-advanced-functions/)
+2. [Create alerts and notifications in Sysdig Monitor](/sysdig-monitor-create-alert-channels/)
+3. [Set up advanced metrics in Sysdig Monitor](/sysdig-monitor-set-up-advanced-functions/)
 
 If you have any questions about Sysdig or application monitoring, please contact the Platform Services team on the [#devops-sysdig Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
 

--- a/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
+++ b/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
@@ -21,18 +21,18 @@ sort_order: 4
 # Set up advanced metrics in Sysdig Monitor
 
 ## On this page
-- [Use Service Discovery to import application metrics endpoints](#sysdig-service-discovery)
-- [Create a PromQL based alert](#promql-alert)
-- [Use Service Discovery to import application metrics endpoints](#sysdig-service-discovery)
+- [Creating PromQL metrics](#creating-promql-metrics)
+- [Create a PromQL based alert](#create-a-promql-based-alert)
+- [Use Service Discovery to import application metrics endpoints](#use-service-discovery-to-import-application-metrics-endpoints)
 
 
-## Creating PromQL metrics<a name="explore-promql"></a>
+## Creating PromQL metrics
 Sysdig scrapes Prometheus metrics, you can create custom queries using PromQL. Here is a great way to start exploring:
 
 ![Sysdig exploring](../../images/sysdig_team_promql_explore.png)
 
 
-## Create a PromQL based alert<a name="promql-alert"></a>
+## Create a PromQL based alert
 PromQL can be used in Alerts as well. The following example shows an alert for the **Persistent Volume Utilization** when hitting 80% full. 
 
 - If you'd like to get PVC-specific metrics, for example, get the max percentage of storage usage:
@@ -46,7 +46,7 @@ PromQL can be used in Alerts as well. The following example shows an alert for t
 ![Configure PromQL alert](../../images/sysdig-team-alert-config-promql.png)
 
 
-## Use Service Discovery to import application metrics endpoints<a name="sysdig-service-discovery"></a>
+## Use Service Discovery to import application metrics endpoints
 
 Sysdig has a lightweight Prometheus server (Promscrape) that can [import your application metrics endpoint into Sysdig metrics](https://docs.sysdig.com/en/docs/sysdig-monitor/monitoring-integrations/custom-integrations/collect-prometheus-metrics/migrating-from-promscrape-v1-to-v2/#migrate-using-default-configuration).
 

--- a/src/docs/app-monitoring/sysdig-monitor-setup-team.md
+++ b/src/docs/app-monitoring/sysdig-monitor-setup-team.md
@@ -27,14 +27,14 @@ The Sysdig Teams Operator runs in the cluster and enables a team to create and m
 For more information on Sysdig Monitor, see [Monitoring with Sysdig](%WORDPRESS_BASE_URL%/private-cloud/our-products-in-the-private-cloud-paas/monitoring-with-sysdig/).
 
 ## On this page
-- [Sign in to Sysdig](#sign-in-sysdig)
-- [Create Sysdig team access](#create-access)
-- [Verify Sysdig Team Creation](#verify-team-creation)
-- [Review your monitoring dashboards](#review-dashboards)
-- [Troubleshoot access issues](#troubleshooting)
+- [Sign in to Sysdig](#sign-in-to-sysdig)
+- [Create Sysdig team access](#create-sysdig-team-access)
+- [Verify Sysdig team creation](#verify-sysdig-team-creation)
+- [Review your monitoring dashboards](#review-your-monitoring-dashboards)
+- [Troubleshooting](#troubleshooting)
 
 
-## Sign in to Sysdig<a name="sign-in-sysdig"></a>
+## Sign in to Sysdig
 You and your team must sign in to Sysdig to create the user account. The B.C. government Sysdig uses OpenID Connect and requires a GitHub account.
 
 - Go to the [BCDevOps Sysdig Monitor](https://app.sysdigcloud.com/api/oauth/openid/bcdevops).
@@ -48,7 +48,7 @@ You and your team must sign in to Sysdig to create the user account. The B.C. go
   - **Note:** Sysdig identifies users by the email, so it's important to use the correct email address for yourself as well as your team members.
 
 
-## Create Sysdig Team Access<a name="create-access"></a>
+## Create Sysdig team access
 The OpenShift Operator runs in the background and creates a Sysdig team RBAC and dashboard for you. The operator looks for a `sysdig-team` custom resource from your `*-tools` namespace. There are two parts of work to create Sysdig team access.
 
 
@@ -95,7 +95,7 @@ oc project <PROJECT_SET_LICENSE_PLATE>-tools
 oc apply -f sysdig-team-sample.yaml
 ```
 
-## Verify Sysdig team creation<a name="verify-team-creation"></a>
+## Verify Sysdig team creation
 
 Use `oc describe sysdig-team <PROJECT_SET_LICENSE_PLATE>-sysdigteam` to validate that the Sysdig team was created:
 
@@ -151,7 +151,7 @@ To access them:
 ![Switch to the new sysdig team](../../images/sysdig-team-switch.png)
 
 
-## Review your monitoring dashboards<a name="review-dashboards"></a>
+## Review your monitoring dashboards
 
 You should see the following dashboard templates from your Sysdig team:
 - A resource dashboard template provides an overview of resource allocation for production namespace. You can make copies of it for different environments.
@@ -163,7 +163,7 @@ You should see the following dashboard templates from your Sysdig team:
 > **Note:** The Platform Services team recommends that you use the [Sysdig API](https://docs.sysdig.com/en/docs/developer-tools/sysdig-rest-api-conventions/) to keep your dashboards as code. Each dashboard is assigned to an account on Sysdig for ownership. If you delete the user (whether from the console or custom resource), all of the dashboards are deleted. Sysdig Cloud (SaaS) does not provide a service to retain the deleted dashboards for a user.
 
 
-## Troubleshooting <a name="troubleshooting"></a>
+## Troubleshooting
 
 - Error from `sysdig-team` custom resource: if you don't see `Awaiting next reconciliation` after waiting for 5 minutes, contact the Platform Services team on the [#devops-sysdig Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig). Make sure to include the OpenShift cluster and namespace information.
 

--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -22,24 +22,24 @@ sort_order: 2
 One of the most amazing benefits of working on OpenShift is that, when your application has been designed with a few key ideas in mind, you can avoid many of the regular outages that are almost unavoidable on legacy infrastructure. All that time you used to spend with your application down because you needed to patch a server? Gone. If a node needs to go down for patching purposes, a correctly designed application can simply spin up another pod on another node, and your users won't even notice. Sounds great, right? But the question is, then: how do you design an application for OpenShift if it's so different from applications designed for legacy infrastructure?
 
 ## On this page
-- [What does "Correctly Designed" mean?](#correctly-designed)
-- [A Monitored App](#monitored)
-- [A Highly Available App](#highly-available)
-- [An Easily Deployable App](#easily-deployable)
-- [A Recoverable App](#recoverable)
-- [A Correctly Resourced App](#resourced)
-- [A Well Behaved App](#behaved)
-- [Community Support](#community-support)
+- [What does correctly designed mean?](#what-does-correctly-designed-mean)
+- [A monitored application](#a-monitored-application)
+- [A highly available application](#a-highly-available-application)
+- [An easily deployable application](#an-easily-deployable-application)
+- [A recoverable application](#a-recoverable-application)
+- [A correctly resourced application](#a-correctly-resourced-application)
+- [A well behaved application](#a-well-behaved-application)
+- [Community support](#community-support)
 - [Tools](#tools)
 - [Examples](#examples)
 
-## What does correctly designed mean?<a name="correctly-designed"></a>
+## What does correctly designed mean?
 
 All you need to do is make sure that your application takes advantage of OpenShift through some specific design requirements. These are outlined through the concept of a [12 factor application](https://12factor.net/). 
 
 **Note:** If you're a technical user looking for some help on how to make a 12-factor application, go to the bottom of this document for examples of applications that run in a resilient manner on the platform. Feel free to ask those teams for some advice on how they got there.
 
-## A monitored application<a name="monitored"></a>
+## A monitored application
 
 An application that runs without failing most of the time is great, but things happen. Maintenance, failures, network problems and sneaky little issues in the design or implementation of your application can cause strange behaviours or outages. The platform is extremely highly available, (99.98% available for the last 12 months as of mid-2022) but that doesn't mean you should assume that your application is guaranteed the same availability. Application outages can happen for reasons other than full platform outages.
 
@@ -54,7 +54,7 @@ Many of these notification options provide your team an opportunity to act to pr
 
 Your team should also ensure you are in the [#devops-alerts channel](https://chat.developer.gov.bc.ca/channel/devops-alerts) in Rocket.Chat where notices of upcoming maintenance are posted. There are not many messages sent in this channel, so we recommend switching your Rocket.Chat notification settings for the channel to **All messages**.
 
-## A highly available application<a name="highly-available"></a>
+## A highly available application
 
 The platform may have very high availability in general, but our individual nodes do not. This doesn't mean the nodes are unstable or difficult to use. It just means that the way we approach maintenance and infrastructure problems are a little different from the way things work in the legacy application world. Did you know that we don't guarantee a single node will be up for more than 24 hours at a time? That's right. Our nodes will be restarted or changed very often. This might sound like a big problem with the platform, but it's actually a feature. It means that the platform team can be extremely proactive about keeping the platform's physical infrastructure in great shape.
 
@@ -64,17 +64,17 @@ There are plenty of options for ensuring that this change in approach helps your
 
 ![Markdown Flow Chart](../../images/availability.png)
 
-## An easily deployable application<a name="easily-deployable"></a>
+## An easily deployable application
 
 Because all applications on OpenShift should be architected with the expectation that any node can go down at any time, it's imperative that applications be easy and quick to redeploy. This requires - most importantly - **no human interaction in the process**. Once the platform is given the command to deploy your software on a new pod, the process between starting up that new pod and having an accessible and usable application should require no human interference whatsoever.
 
 This means that all of your deployment configuration should be automated and kept in source-control to ensure that it is easily accessible, consistent, and up-to-date at all times. That includes any side processes like your monitoring tasks from the section above.
 
-## A recoverable application<a name="recoverable"></a>
+## A recoverable application
 
 This part isn't so different from legacy applications. If you need to recover your application due to data corruption or some other significant failure, it's important that your application be architected to do so quickly and easily. Most of this is covered by having an application that is easily deployable, but it's also important that you have the ability to recover any stateful data or configurations that cannot be held in a repository. In other words, you need to be able to recover your database and application passwords.
 
-## A correctly resourced application<a name="resourced"></a>
+## A correctly resourced application
 
 Ensuring your application has the resources it needs, without taking too much, is a balancing act. Different applications and environments will also need different levels of service.
 
@@ -90,7 +90,7 @@ If your pod has limits higher than its requests it will run Burstable and get at
 
 If your pod has the requests and limits set to the same value then it will run Guaranteed QoS class. It will have preferential access to compute resources and will be the last to be evicted if a node should become overloaded. This is best for applications in the prod namespace as they need the best uptime.
 
-## A well behaved application<a name="behaved"></a>
+## A well behaved application
 
 It is important to ensure your application is well behaved and doesn't impede the cluster's Operator work or impact the cluster's ability to heal.
 
@@ -102,7 +102,7 @@ If your application is making use of [pod disruption budgets](https://kubernetes
 
 Ensure that your pods are not in a `CrashLoopBackOff` state for too long. If they have been crashing for more than a day the Platform Operations team might just delete them or scale down their replicaset.
 
-## Community support<a name="community-support"></a>
+## Community support
 
 You may note that this document is pretty vague about the "hows" of these principles. This is because it can vary from application to application, and technology stack to technology stack. The design needs for a highly available chat application are very different from those of a highly available static website.
 
@@ -112,7 +112,7 @@ This is where the community comes in. If you have a highly available application
 
 It's also very important to remember that in the B.C. government, we are part of a larger, international community of developers working to create better and more resilient applications. There are a lot of great resources available on the broader internet that we could never hope to match here.
 
-## Tools<a name="tools"></a>
+## Tools
 
 The Developer Exchange community is full of great developers seeking ways to help the rest of the community. Here are some examples of tools that you can use to help build a more resilient application:
 
@@ -126,7 +126,7 @@ The Developer Exchange community is full of great developers seeking ways to hel
 * An open-source option for creating a highly available Postgres cluster
 
 
-## Examples<a name="examples"></a>
+## Examples
 
 The following are some fantastic examples of applications that operate on the platform with high resiliency design, as well as a couple of quick summaries of how and why the teams who built the applications made the decisions they did. If you're aiming to build something similar to an application shown here, please always feel free to ask the team in question for their advice on how to make your application more resilient as well.
 
@@ -150,7 +150,6 @@ The following are some fantastic examples of applications that operate on the pl
 * a chain-build gastby (react app) that builds nodejs into a caddy server
 
 **Note:** If your team has a resilient design of any kind - even if you haven't perfected it - please fork this document and add your repository as an example. Nobody is perfect, and in-progress examples are a great help for teams trying to learn where to start.
-
 
 ---
 Related links:

--- a/src/docs/automation-and-resiliency/argo-cd-shared-instances.md
+++ b/src/docs/automation-and-resiliency/argo-cd-shared-instances.md
@@ -27,10 +27,10 @@ A new Argo CD instance is available to product teams that are interested in usin
 ## On this page
 
 - [Design](#design)
-- [Configuration](#config)
+- [Configuration](#configuration)
 - [Access](#access)
 
-## Design<a name="design"></a>
+## Design
 
 A shared instance of Argo CD exists in each OpenShift cluster. Product teams that request access to Argo CD are given their own project. There is a one-to-one relationship between Argo CD projects and OpenShift Platform (OCP) project sets/licence plates (`tools`, `dev`, `test` and `prod` namespaces). Teams can configure as many applications as they need and deploy them to any of the OCP namespaces in their project set. Each application/environment combination is configured as a separate application in Argo CD.
 
@@ -38,7 +38,7 @@ A shared instance of Argo CD exists in each OpenShift cluster. Product teams tha
 
 Each team gets a new GitHub repository so they can manage their application manifests. Teams manage multiple applications from this repository, each having its own directory or branch.
 
-## Configuration<a name="config"></a>
+## Configuration
 
 ### Source repositories
 Application code resides in existing repositories. The new repository is for the YAML manifest files that are consumed by Argo CD. The project is limited to using this one repository for Argo CD configurations.
@@ -49,7 +49,7 @@ Each project can deploy applications to any of the OpenShift namespaces in their
 ### Allowed resources
 Projects don't have access to alter any cluster-level resources, only namespace-level resources.
 
-## Access<a name="access"></a>
+## Access
 
 Access to an Argo CD project is based on membership in a Keycloak group unique to that project. The team can manage their Keycloak group membership themselves with a `CustomResourceDefinition` defined in a YAML file in their own GitHub repository. An operator consumes these YAML files and maintains Keycloak group membership so that teams don't have to make a request to the Platform Services team.
 

--- a/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
+++ b/src/docs/automation-and-resiliency/cicd-pipeline-templates-for-private-cloud-teams.md
@@ -25,18 +25,18 @@ As you develop your application for deployment to the BC Gov Private Cloud PaaS 
 ## On this page
 - [Pipeline templates](#pipeline-templates)
 - [Automation technologies](#automation-technologies)
-- [Choose a technology](#choose-technology)
-- [Contribute to a pipeline template](#contribution)
+- [Choose a technology](#choose-a-technology)
+- [Contribute to a pipeline template](#contribute-to-a-pipeline-template)
 
 To help teams that want to get started with pipeline automation, use the best security practices for pipeline development, or both, the Platform Services team created pipeline templates for automation technologies supported on the Private Cloud platform.
 
 **Note**: Supported technologies are available on the platform, and the Platform Services team has expertise with these technologies to help the product teams that use it. Product teams can use any other automation technology outside of the platform, but the Platform Services team might not have the expertise to support them if they need help
 
-## Pipeline templates<a name="pipeline-templates"></a>
+## Pipeline templates
 
 Any product teams working in the Silver or Gold clusters on the BC Gov Private Cloud PaaS can use pipeline templates. For guides on getting started with each of the supported technologies, see the [Security Pipeline Templates](https://github.com/bcgov/security-pipeline-templates) repository.
 
-## Automation technologies<a name="automation-technologies"></a>
+## Automation technologies
 
 Currently, the following technologies are available to product teams:
 - [ArgoCD](https://github.com/BCDevOps/openshift-wiki/blob/b1a4e6db91932fd3f29705a5c8ee44983abf8763/docs/ArgoCD/argocd_info.md)
@@ -45,7 +45,7 @@ Currently, the following technologies are available to product teams:
 
 While Jenkins is technically supported on the platform, the Platform Services team highly discourages teams from using this technology as it's inefficient with the use of valuable platform resources. Over the next few months we'll be guiding the teams that currently use Jenkins to transition to a more modern and efficient technology.
 
-## Choose a technology<a name="choose-technology"></a>
+## Choose a technology
 
 Each team should make the final decision on which technology they want to use and may depend on their experience and comfort with each tool. The Platform Services team recommends the following, depending on your team's level of experience:
 
@@ -61,7 +61,7 @@ While teams can use GitHub Actions for both builds (CI) and deployments (CD), Ar
 
 - An improved security model
 
-## Contribute to a pipeline template<a name="contribution"></a>
+## Contribute to a pipeline template
 
 If you want to contribute to a pipeline template, you can fork a repository and add more steps to the templates or make any modifications to improve the template. Submit a pull request and tag any of the platform administrators for review.
 

--- a/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
+++ b/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
@@ -27,13 +27,13 @@ New project sets provisioned in **all clusters** of the BC Gov Private Cloud Paa
 **Note**: The Platform Services team may approach your team to discuss a downgrade in your quota if they find your application isn't using all of the resources within the current quota.
 
 ## On this page
-- [CPU quotas](#cpu)
-- [Memory quotas](#memory)
-- [Storage quotas](#storage)
+- [CPU quotas](#cpu-quotas)
+- [Memory quotas](#memory-quotas)
+- [Storage quotas](#storage-quotas)
 
 If the default allocations aren't sufficient for your application, [you can ask for a quota increase](/request-quota-increase-for-openshift-project-set/). You'll need a Sysdig dashboard that shows that your application needs more of a specific resource type (CPU, RAM or storage) in a specific namespace. Provide this proof to the Platform Services team before they can approve a quota increase that you submit in the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing).
 
-## CPU quotas<a name="cpu"></a>
+## CPU quotas
 
 The following CPU quotas are currently available on the platform. All CPU requests and limits are shown in cores (not millicores) and represent the maximum for the combined CPU request or CPU limit values for **all pods in a namespace**.
 
@@ -47,7 +47,7 @@ cpu-request-16-limit-32: CPU Request 16 cores, CPU Limit 32 cores
 cpu-request-32-limit-64: CPU Request 32 cores, CPU Limit 64 cores
 ```
 
-## Memory quotas<a name="memory"></a>
+## Memory quotas
 
 The following RAM quotas are currently available on the platform. All memory requests and limits are shown in GiB and represent the **maximum** for the combined RAM request or RAM limit values for **all pods in the namespace**.
 
@@ -60,7 +60,7 @@ memory-request-32-limit-64: RAM Request 32 GiB, RAM Limit 64 GiB
 memory-request-64-limit-128: RAM Request 64 GiB, RAM Limit 128 GiB
 ```
 
-## Storage quotas<a name="storage"></a>
+## Storage quotas
 
 The following storage quotas are currently available on the platform. All storage sizes are in GiB and represent the **maximum** for the combined storage for **all PVCs within the namespace**. All storage quotas allow for up to 60 persistent volume claims (PVCs).
 

--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -29,24 +29,24 @@ Before asking for more quota for your project set, check if the application is f
 - [Application Resource Tuning](https://github.com/BCDevOps/developer-experience/blob/master/docs/resource-tuning-recommendations.md)
 
 ## On this page
-- [Set up resource monitoring with Sysdig Monitor](#setup-sysdig)
-- [Request a quota increase](#request-increase)
-- [Collect application metrics](#collect-metrics)
+- [Set up resource monitoring with Sysdig Monitor](#set-up-resource-monitoring-with-sysdig-monitor)
+- [Request a quota increase](#request-a-quota-increase)
+- [Collect application metrics](#collect-application-metrics)
 
-## Set up resource monitoring with Sysdig Monitor<a name="setup-sysdig"></a>
+## Set up resource monitoring with Sysdig Monitor
 
 Use Sysdig to monitor your application. You can access dashboards that show your application memory, CPU and storage usage.
 
 Before you ask for a quota increase, the Platform Services team wants you to monitor and collect metrics to show how much resource your application uses. For more information, see [Get Started with Sysdig Monitor](https://developer.gov.bc.ca/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring). The documentation has all you need to onboard onto Sysdig and use the default dashboards. If you have any issues onboarding to Sysdig, contact the Platform Services team on the applicable [Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
 
-## Request a quota increase<a name="request-increase"></a>
+## Request a quota increase
 **Note**: Before you request a quota increase, make sure that your project is using its resources efficiently. The Platform Services team wants to be very confident your project needs more quota before they grant an increase.
 
 If you determine that your application needs a quota increase, you can have a product owner or technical lead on your project make the request on the **Project Edit** page on the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing). The Platform Services team must approve the request before it's processed.
 
 If you need more resources for CPU, RAM or storage in any of the four namespaces (`dev`, `test`, `tool` or `prod`), you must submit a standard quota increase request through the Platform Project Registry. For more information on quotas, see [OpenShift project resource quotas](/openshift-project-resource-quotas/).
 
-## Collect application metrics<a name="collect-metrics"></a>
+## Collect application metrics
 
 The Platform Services team needs to know if your application is using the current quotas efficiently. If you're running out of quota, the team wants to review resource-consumption statistics. If you're preparing for an application load increase, the team wants to know the expected increase and how much growth room you still have.
 

--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -25,8 +25,8 @@ There are three different resource types on the platform:
 - Storage
 
 Before asking for more quota for your project set, check if the application is fully using the resources and confirm that the usage is expected. Use the following information to help determine the level of resource the application needs:
-- [Resource Management Guidelines](https://github.com/BCDevOps/developer-experience/blob/master/docs/ResourceManagementGuidelines.md)
-- [Application Resource Tuning](https://github.com/BCDevOps/developer-experience/blob/master/docs/resource-tuning-recommendations.md)
+- [Resource management guidelines](https://github.com/BCDevOps/developer-experience/blob/master/docs/ResourceManagementGuidelines.md)
+- [Application resource tuning](/application-resource-tuning/)
 
 ## On this page
 - [Set up resource monitoring with Sysdig Monitor](#set-up-resource-monitoring-with-sysdig-monitor)

--- a/src/docs/build-deploy-and-maintain-apps/image-artifact-management-with-artifactory.md
+++ b/src/docs/build-deploy-and-maintain-apps/image-artifact-management-with-artifactory.md
@@ -25,13 +25,13 @@ Artifactory is an artifact repository system by JFrog. This service is available
 For more information on Artifactory from JFrog, see the [Artifactory documentation](https://www.jfrog.com/confluence/site/documentation).
 
 ## On this page
-- [Remote (caching/proxy) repository access](#remote-repos)
-- [Local private repositories](#local-repos)
-- [Xray artifact scanning](#xray)
-- [Security reviews](#security)
-- [Artifactory support, processes, and communications](#support-processes-comms)
-- [Service improvements and disruptions](#service-improvements)
-- [Set up Artifactory](#setup)
+- [Remote (caching/proxy) repository access](#remote-cachingproxy-repository-access)
+- [Local private repositories](#local-private-repositories)
+- [Xray artifact scanning](#xray-artifact-scanning)
+- [Security reviews](#security-reviews)
+- [Artifactory support, processes, and communications](#artifactory-support-processes-and-communications)
+- [Service improvements and disruptions](#service-improvements-and-disruptions)
+- [Set up Artifactory](#set-up-artifactory)
 
 Use Artifactory to access artifacts for your application. It's compatible with all major package types, including Docker images, Helm charts, NPM packages and more. For more information on package management, see [Package Management](https://www.jfrog.com/confluence/display/JFROG/Package+Management).
 
@@ -47,7 +47,7 @@ We deployed Artifactory in a highly available configuration in the B.C. governme
 
 There is no charge to use Artifactory.
 
-## Remote (caching/proxy) repository access<a name="remote-repos"></a>
+## Remote (caching/proxy) repository access
 
 Access to remote (caching) repositories is available by default to anyone in the Silver or Gold clusters. When a project set is provisioned, an Artifactory service account is created at the same time, with a secret in the tools namespace available to use.
 
@@ -59,7 +59,7 @@ jq -r '(["ARTIFACTORYKEY","SOURCEURL"] | (., map(length*"-"))), (.[] | [.key, .u
 
 If there is a specific public repository you want to see cached through Artifactory, reach out to the Platform Services team to ask about adding it.
 
-## Local private repositories<a name="local-repos"></a>
+## Local private repositories
 You can use a local private repository to push your own artifacts and images, with control over access. The benefits include the following:
 
 * You'll have a common space to store sensitive artifacts and images.
@@ -72,7 +72,7 @@ You can use a local private repository to push your own artifacts and images, wi
 
 You need to set up an Artifactory project before you can get a local private repository. For more information, see [Setup an Artifactory project and repository](/setup-artifactory-project-repository/).
 
-## Xray artifact scanning<a name="xray"></a>
+## Xray artifact scanning
 The Xray tool scans all artifacts for security issues and lets you know about potential issues. This gives you an opportunity to deal with issues before they become a problem. The benefits include the following:
 
 * Getting images scanned is easy. You only need a private repository in Artifactory.
@@ -81,11 +81,12 @@ The Xray tool scans all artifacts for security issues and lets you know about po
 
 * You can ensure all of your images - especially your production images - are secure without placing additional load on your developers.
 
-## Security reviews<a name="security"></a>
+## Security reviews
 
 Privacy Impact Assessment (PIA) and Security Threat Risk Assessment (STRA) have been completed for Sysdig Monitor. These assessments are available by request only, the request can be sent to PlatformServicesTeam@gov.bc.ca.
 
-## Artifactory support, processes, and communications<a name="support-processes-comms"></a>
+## Artifactory support, processes, and communications
+
 The team supporting this service administers the Artifactory application, its supporting database and the S3 storage system that contains the packages uploaded to Artifactory.
 
 Your best source for support, configuration and best practices is the developer community that uses Artifactory for their projects. Check out the [`#devops-artifactory` channel on Rocket.Chat](https://chat.developer.gov.bc.ca/channel/devops-artifactory). Service changes are also posted here.
@@ -94,7 +95,7 @@ For further support in the event of an emergency or outage, contact one of the A
 
 For cluster-wide service notifications that could impact Artifactory, monitor the [`#devops-alerts` channel in Rocket.Chat](https://chat.developer.gov.bc.ca/channel/devops-alerts).
 
-## Service improvements and disruptions<a name="service-improvements"></a>
+## Service improvements and disruptions
 
 Artifactory service improvements include software upgrades for both Artifactory and its operator, feature integrations for the operator, bug fixes and more.
 
@@ -102,7 +103,7 @@ These operations don't result in expected disruptions for users. If the Platform
 
 Other operations require turning Artifactory to read-only mode. In read-only mode you'll still be able to pull from Artifactory, but not push. If the team expects a disruption, they'll notify everyone about the planned read-only window at least a day before in the `#devops-artifactory` and `#devops-alerts`channels.
 
-## Set up Artifactory<a name="setup"></a>
+## Set up Artifactory
 
 To get started using Artifactory, see [Setup an Artifactory service account](/setup-artifactory-service-account/).
 

--- a/src/docs/build-deploy-and-maintain-apps/imagestreams.md
+++ b/src/docs/build-deploy-and-maintain-apps/imagestreams.md
@@ -29,7 +29,7 @@ Image streams provide a means of creating and updating container images in an on
 - [Smaller is better](#smaller-is-better)
 - [Usage notifications](#usage-notifications)
 
-## Component parts <a name="component-parts"></a>
+## Component parts
 
 ### Image
 
@@ -45,7 +45,7 @@ There is a pruning script that runs in the evenings. It will remove all but the 
 
 An image stream contains multiple tags.
 
-## Getting Info <a name="getting-info"></a>
+## Getting info
 
 The `oc describe ImageStream` command will provide a lot of info about the images, tags, and streams in your namespace.
 
@@ -99,13 +99,13 @@ Tags:                   9
 
 Here we can see the `python` image stream has several tags. In the `3.8` tag, there are a couple revisions of the image.
 
-## Make use of Tags <a name="make-use-of-tags"></a>
+## Make use of tags
 
 The tag `latest` is commonly used for the most recent build of an image, and likely changes frequently. For production workloads you should rarely use the `latest` tag of an imagestream as it has a high chance of changing unexpectedly and breaking production. Instead, build and push to `latest` then tag that revision to something like `test` for testing and `prod` for production. This lets you test and promote an image in a controlled way.
 
 On the opposite end, be sure to not make too many tags. Some teams create a new tag for each pull request in their continuous integration process. But this can leave a lot of unneeded images in the registry. Be sure to clean up any unused tags after.
 
-## Smaller is better <a name="smaller-is-better"></a>
+## Smaller is better
 
 Since images need to be copied to the host to run the pod and cached there, having smaller images will improve the startup time of the pods.
 
@@ -145,7 +145,7 @@ Exposes Ports:  8080/tcp
 ...
 ```
 
-## Usage Notifications <a name="usage-notifications"></a>
+## Usage notifications
 
 The platform will now be sending a weekly email to teams that are using too much space on the registry. The image registry is a shared service and overuse of it can lead to other teams being unable to push their builds, or to the platform team having to buy more storage space.
 

--- a/src/docs/build-deploy-and-maintain-apps/imagestreams.md
+++ b/src/docs/build-deploy-and-maintain-apps/imagestreams.md
@@ -20,7 +20,7 @@ sort_order: 10
 
 # Best practices for managing image streams
 
-Image streams provide a means of creating and updating container images in an on-going way. As improvements are made to an image, tags can be used to assign new version numbers and keep track of changes.
+Image streams provide a means of creating and updating container images in an ongoing way. As improvements are made to an image, tags can be used to assign new version numbers and keep track of changes.
 
 ## On this page
 - [Component parts](#component-parts)

--- a/src/docs/build-deploy-and-maintain-apps/prebuilt-images.md
+++ b/src/docs/build-deploy-and-maintain-apps/prebuilt-images.md
@@ -35,11 +35,12 @@ The images are available from Artifactory and you can use the `artifactory-creds
 
 ## On this page
 
-- [App Assessment](#app-assessment)
+- [AppAssessment](#appassessment)
 - [Backup container](#backup-container)
 - [Caddy s2i](#caddy-s2i)
+- [CodeQL](#codeql)
 - [MongoDB 3.6 HA](#mongodb-36-ha)
-- [Patroni/Postgres](#patroni-postgres)
+- [Patroni/Postgres](#patronipostgres)
 - [Legacy builds](#legacy-builds)
 
 All project sets on the platform are given a secret called `artifactory-creds` that can be used to pull images from the local Artifactory service. Include this secret in your configuration if you have a deployment or StatefulSet that uses one of these images.
@@ -53,34 +54,34 @@ spec:
       containers:
 ```
 
-## AppAssessment<a name="app-assessment"></a>
+## AppAssessment
 Use the AppAssessment application to identify configuration issues in your namespaces and to improve resource consumption and health checks. For more information, see [AppAssessment](https://github.com/bcgov/AppAssessment).
 
 Images: [AppAssessment images in Artifactory](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/app-assessment)
 
-## Backup container<a name="backup-container"></a>
+## Backup container
 The community's database backup container supports four types of databases. Find an image to:
 - [Manage backups of your **MariaDB** instances](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/backup-container-mariadb) 
 - [Manage backups of your **Mongo** instances](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/backup-container-mongo)
 - [Manage backups of your **MSSQL** instances](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/backup-container-mssql)
 - [Manage backups of your **Postgres** instances](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/backup-container-postgres)
 
-## Caddy s2i<a name="caddy-s2i"></a>
+## Caddy s2i
 [Pipeline templates](https://github.com/bcgov/pipeline-templates) that have been developed for the community use the Caddy s2i image. For more information, see [s21-caddy-nodejs](https://github.com/bcgov/s2i-caddy-nodejs).
 
 Images: [Caddy s2i images in Artifactory](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/caddy-s2i-builder)
 
-## CodeQL<a name="codeql"></a>
+## CodeQL
 [Pipeline templates](https://github.com/bcgov/pipeline-templates) that have been developed for the community use the CodeQL image. For more information, see [codeql](https://github.com/bcgov/pipeline-templates/tree/main/tekton/base/tasks/codeql).
 
 Images: [CodeQL images in Artifactory](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/codeql)
 
-## MongoDB 3.6 HA<a name="mongodb-36-ha"></a>
+## MongoDB 3.6 HA
 This is version 3.6 of a MongoDB image that's ready for highly available applications. For more information, see [mongodb-replicaset-container](https://github.com/bcgov/mongodb-replicaset-container).
 
 Images: [MongoDB images in Artifactory](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/mongodb-36-ha)
 
-## Patroni/Postgres<a name="patroni-postgres"></a>
+## Patroni/Postgres
 This image comes in two versions:
 - Patroni 1.6, with Postgres 12.4
 - Patroni 2.0, with Postgres 12.4
@@ -89,7 +90,7 @@ For more information, see [patroni-postgres-container](https://github.com/bcgov/
 
 Images: [Patroni/Postgres images in Artiactory](https://artifacts.developer.gov.bc.ca/ui/repos/tree/General/bcgov-docker-local/patroni-postgres)
 
-## Legacy builds<a name="legacy-builds"></a>
+## Legacy builds
 Previously, some of these builds were available on the local image registry of each OpenShift cluster in the `bcgov` namespace.
 
 Those builds are still there, but future enhancements will only be made to the images in Artifactory. Legacy builds are rebuilt monthly to let them incorporate security or bug fixes in the base image.

--- a/src/docs/build-deploy-and-maintain-apps/push-pull-artifacts-artifactory.md
+++ b/src/docs/build-deploy-and-maintain-apps/push-pull-artifacts-artifactory.md
@@ -21,11 +21,11 @@ sort_order: 7
 After you've [set up your Artifactory service account](/setup-artifactory-service-account/), you can pull artifacts from the platform's caching repositories. If you wish to push to Artifactory, you will need an [Artifactory project and private repository first](/setup-artifactory-project-repository/). After your set up your private repository, follow these instructions to pull from them.
 
 ## On this page
-- [Pull Docker images from Artifactory](#pull-docker)
-- [Node Package Manager (NPM)](#npm)
+- [Pull Docker images from Artifactory](#pull-docker-images-from-artifactory)
+- [Node Package Manager (NPM)](#node-package-manager-npm)
 - [Maven](#maven)
 
-## Pull Docker images from Artifactory<a name="pull-docker"></a>
+## Pull Docker images from Artifactory
 
 These steps apply to all Docker-type repositories, not just DockerHub. These steps work for any private docker registry, not just Artifactory. Change out the Artifactory URL for the URL of your preferred registry.
 
@@ -118,7 +118,7 @@ Don't forget that you need to update the image URL to point explicitly at Artifa
 
 You can now use this image in your build or deployment.
 
-## Node Package Manager (NPM)<a name="npm"></a>
+## Node Package Manager (NPM)
 The `npm-remote` repository in Artifactory points to the [public default NPM repository](https://registry.npmjs.org). If you wish to pull from a different repository, such as a private one, replace all references to `npm-remote` below with your repository's name.
 
 1. Set the NPM registry:
@@ -160,7 +160,7 @@ curl -u $AF_USERID:$AF_PASSWD https://artifacts.developer.gov.bc.ca/artifactory/
 ```
 For example, you can check out the [Repo-Mountie assemble file](https://github.com/bcgov/repomountie/blob/master/.s2i/bin/assemble).
 
-## Maven<a name="maven"></a>
+## Maven
 
 To deploy build artifacts through Artifactory you need to add a deployment element with the URL of a target local repository where you want to deploy your artifacts. For example:
 

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-project-repository.md
@@ -23,15 +23,15 @@ sort_order: 8
 If your team wishes to push artifacts to Artifactory, you will require a private repository to do so. This feature is provided via Artifactory Projects. Artifactory Projects are logical spaces of quota-based storage which teams can administer themselves. Within an Artifactory Project, a team can create their own private repositories - any number and any type that suits their needs, so long as the storage space required for these repositories remains within the provided quota.
 
 ## On this page
-- [Create an Artifactory project](#create-project)
-- [Request a larger quota for your Artifactory project](#request-quota)
-- [Access your new project](#access-project)
-- [Add users and service accounts to a project](#add-users)
-- [Add a repository to your project](#add-repo)
+- [Create an Artifactory project](#create-an-artifactory-project)
+- [Request a larger quota for your Artifactory project](#request-a-larger-quota-for-your-artifactory-project)
+- [Access your new project](#access-your-new-project)
+- [Add users and service accounts to a project](#add-users-and-service-accounts-to-a-project)
+- [Add a repository to your project](#add-a-repository-to-your-project)
 
 A team can request more quota if required, but note that teams are expected to try to remain within the default quota as much as possible - so be sure to clean up your old artifacts and tags.
 
-## Create an Artifactory project<a name="create-project"></a>
+## Create an Artifactory project
 Artifactory Projects give teams access to private repositories. If you want a private repository where you can push your own images or other artifacts, you'll need a project. If you don't want to be able to push your own images or other artifacts - if you only wish to use Artifactory remote repositories - you don't need a project.
 
 You can create an `ArtifactoryProject` object on your OpenShift namespace with the following command:
@@ -54,7 +54,7 @@ You may also see **nothing-to-approve**. This status is meant to say that there 
 
 **Note**: While you are able to patch the `approval_status` box, it doesn't mean you can approve your own project. The box is there for informational purposes. If you change it, Archeobot changes it back.
 
-## Request a larger quota for your Artifactory project<a name="request-quota"></a>
+## Request a larger quota for your Artifactory project
 
 The default quota for any Artifactory Project is 5 GB. This should be sufficient for the needs of most teams on the platform, as long as the artifacts pushed to Artifactory are well-controlled. Teams must delete old artifacts that are no longer in use in order to remain below this threshold.
 
@@ -73,7 +73,7 @@ If the team maintains the rejection, make sure you acknowledge the rejection. If
 
 After you've made the change, Archeobot reconciles once more and you'll see that your `approval_status` changes back to `nothing-to-approve` (or you will have deleted the ArtifactoryProject object, in which case you won't see anything at all). This means your rejection has been acknowledged and you can make further change requests.
 
-## Access your new project<a name="access-project"></a>
+## Access your new project
 
 Once you have your Artifactory project you can add repositories and users, adjust roles and check the results of Xray scans on artifacts.
 
@@ -85,7 +85,7 @@ To use these features, enter the project in the Artifactory UI. Log in and expan
 
 After you've entered the project in the Artifactory UI, some tabs with boxes and gears are visible. Click the gears to enter the administrator space in your project.
 
-## Add users and service accounts to a project<a name="add-users"></a>
+## Add users and service accounts to a project
 
 Once you've gotten your project, make sure to add your own service account to the project, as it's not added automatically when the project is created.
 
@@ -101,7 +101,7 @@ You can also add any Artifactory service account and select multiple users to ad
 
 You can also add additional roles to the project, if you want more finely-tuned control over who gets access to what.
 
-## Add a repository to your project<a name="add-repo"></a>
+## Add a repository to your project
 
 To add a repository to your project, do the following:
 1. Click the gear icon and then choose **Repositories**. Click **Add Repositories**.

--- a/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
+++ b/src/docs/build-deploy-and-maintain-apps/setup-artifactory-service-account.md
@@ -24,18 +24,18 @@ Artifactory access is controlled through Artifactory service accounts. Service a
 
 ## On this page
 - [Archeobot](#archeobot)
-- [Setup a service account](#setup)
-- [Create multiple service accounts](#multiple-accounts)
-- [Delete a service account](#delete)
+- [Setup a service account](#setup-a-service-account)
+- [Create multiple service accounts](#create-multiple-service-accounts)
+- [Delete a service account](#delete-a-service-account)
 
-## Archeobot<a name="archeobot"></a>
+## Archeobot
 
 [Archeobot](https://github.com/bcgov/platform-services-archeobot) is a custom operator that gives teams the freedom to manage their own Artifactory resources. Archeobot can be used to:
 * Create new Artifactory service accounts.
 * Request new Artifactory projects.
 * Request quota changes to existing Artifactory projects.
 
-## Setup a service account<a name="setup"></a>
+## Setup a service account
 
 Use the information below to request an Artifactory repository or service account.
 
@@ -61,7 +61,7 @@ Users with edit and administrator access on the `tools` namespace can also creat
 
 If either of the secrets is deleted manually, the operator can act to change the password of the service account. Then it recreates one or both secrets with the new password. This is an easy method for teams to change their service account passwords.
 
-## Create multiple service accounts<a name="multiple-accounts"></a>
+## Create multiple service accounts
 You're able to make as many Artifactory service accounts as you need, in as many namespaces as required. Be aware that Archeobot needs to be able to keep up with the amount you're making.
 
 Run the following command to create a new service account:
@@ -72,7 +72,7 @@ The `ASAname` is the name of the ArtifactoryServiceAccount object. It's not the 
 
 For example, if you make an account specifically for use in your Jenkins pipeline, you might want to use the name `jenkins` for the Artifactory Service Account object. This results in a secret called `artifacts-jenkins-[random]` and an account name called `jenkins-[namespace]-[random]`. Don't worry about name collisions with other teams, your account name has your namespace plate in it (the six alphanumeric characters that go before the `-tools`, `-dev`, `-test` or `-prod` in the namespace name), so even if there's another team who called their ArtifactoryServiceAccount `jenkins`, they have a different name.
 
-## Delete a service account<a name="delete"></a>
+## Delete a service account
 You can delete a service account by deleting the ArtifactoryServiceAccount object through the OpenShift CLI. Use the following command:
 `oc delete ArtifactoryServiceAccount [ASAname]` or `oc delete artsvcacct [ASAname]`.
 

--- a/src/docs/database-and-api-management/database-backup-best-practices.md
+++ b/src/docs/database-and-api-management/database-backup-best-practices.md
@@ -120,7 +120,7 @@ Backup problems can appear in two different ways:
 
 The second problem can remain hidden until you need the dump file. By then, it's too late, and you've lost data. In order to avoid this problem, your backup automation should include a step to recover your data into a temporary database. It should also include a test to make sure the expected data is present. Since you'll want to automate your recovery process anyway (as mentioned in [Recovering your data](#recovering-your-data)), this is a good opportunity to test it!
 
-Both the backup and recovery test should send notifications to your team. The Platform Team recommends that you send notifications of both successes and failures. That way, if some failure prevents a notification from being sent, you can still tell there's a problem. Most teams set up a Rocketchat webhook to recieve the status information of both the backup and recovery processes. Teams usually set up the webhook to post these messages to a private channel for the team.
+Both the backup and recovery test should send notifications to your team. The Platform Team recommends that you send notifications of both successes and failures. That way, if some failure prevents a notification from being sent, you can still tell there's a problem. Most teams set up a Rocket.Chat webhook to receive the status information of both the backup and recovery processes. Teams usually set up the webhook to post these messages to a private channel for the team.
 
 ## Recovering your data
 

--- a/src/docs/database-and-api-management/database-backup-best-practices.md
+++ b/src/docs/database-and-api-management/database-backup-best-practices.md
@@ -22,9 +22,11 @@ sort_order: 3
 
 If something bad happens to your database, you will want to recover your application's data quickly, easily, and with up-to-date data. With that goal in mind, your data recovery plan should include these three considerations:
 
+- [Database backup basics](#database-backup-basics)
 - [Backing up your data](#backing-up-your-data)
 - [Recovering your data](#recovering-your-data)
 - [Monitoring your database](#monitoring-your-database)
+- [Automated backup solutions](#automated-backup-solutions)
 
 Don't forget: **Automate Everything!** You should automate every part of your data recovery plan, as much as possible! Automation makes your data recovery plan faster and more reliable.
 

--- a/src/docs/database-and-api-management/database-backup-best-practices.md
+++ b/src/docs/database-and-api-management/database-backup-best-practices.md
@@ -189,7 +189,7 @@ The recovery plan questions at a glance:
 * **How often you want to back up your data?** Configurable, but daily by default.
 * **Where will the backups be stored?** An `nfs-file-backup` PVC. If you wish to use S3, you can add your own small automation step to send the dump file to your bucket.
 * **How many backup files will you keep?** Configurable, but 6 daily, 4 weekly, 1 monthly by default.
-* **How will your team be notified of backup problems?** Includes built-in steps for sending status of both backup and recovery test to Rocketchat.
+* **How will your team be notified of backup problems?** Includes built-in steps for sending status of both backup and recovery test to Rocket.Chat.
 * **How will your team access your dump files?** The built-in recovery process assumes that you already have a dump file on en `nfs-file-backup` PVC. Any additional steps to get it there (either by pulling from S3 or recovering the PVC) must be performed by the team.
 * **What does the recovery process look like?** The built-in recovery process only recovers the dump file into an empty database. If you wish to use point-in-time recovery, your team will need to build appropriate automation for that. You will also need to cover any additional considerations for connecting your application to your recovered database or the recreation of other necessary objects.
 * **How will your database be monitored?** Your team will need to set up their own monitoring.

--- a/src/docs/design-system/about-the-design-system.md
+++ b/src/docs/design-system/about-the-design-system.md
@@ -24,21 +24,21 @@ The [BC Government Design System for Digital Services](https://developer.gov.bc.
 
 ## On this page
 
-- [Design system management](#management)
-- [How the design system works](#design-system)
-- [Contribute to the design system](#contribute)
+- [Design system management](#design-system-management)
+- [How the design system works](#how-the-design-system-works)
+- [Contribute to the design system](#contribute-to-the-design-system)
 
 Components are collectively built by the government community, meet accessibility standards and are open for input and improvement.
 
 Use the design system to customize B.C. government sites and applications. For more information about applying for external URLs, contact the B.C. government [Joint Working Group](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/digital-delivery/web-property-process/web-property-applications).
 
-## Design system management<a name="management"></a>
+## Design system management
 
 A team of designers, developers and the government community manage the design system. The system is part of DevHub, a project that brings together user interface and backend resources for digital teams.
 
 The design system is open source, which means that anybody can provide input, offer suggestions and get involved. The system is collectively built and maintained by the government community.
 
-## How the design system works<a name="design-system"></a>
+## How the design system works
 
 The design system gives developers the tools they need to build digital government products and services. Because the community produces all tools and resources, we're committed to:
 
@@ -48,7 +48,7 @@ The design system gives developers the tools they need to build digital governme
 
 - **Open-source development:** The system is built in GitHub and meant to be shared and improved by everyone. The code is open source and our work is in the open. We are transparent about how choices are made and tools are improved.
 
-## Contribute to the design system<a name="contribute"></a>
+## Contribute to the design system
 
 You can contribute to the design system by doing any of the following:
 

--- a/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
+++ b/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
@@ -25,12 +25,12 @@ Access to the OpenShift platform is self-serve and is available to IDIR users an
 Existing bcgov organization members can invite other users to the organization. Every team member may not need access to OpenShift. Consider the security principle of least privilege before requesting platform access and when granting namespace-level access.
 
 ## On this page
-- [Prerequisites](#prereqs)
+- [Prerequisites](#prerequisites)
 - [Add users](#add-users)
-- [Request platform access](#request-access)
-- [Grant namespace access](#grant-access)
+- [Request platform access](#request-platform-access)
+- [Grant namespace access](#grant-namespace-access)
 
-## Prerequisites<a name="prereqs"></a>
+## Prerequisites
 
 If you want to grant a new user access to OpenShift they must have the following:
 
@@ -39,7 +39,7 @@ If you want to grant a new user access to OpenShift they must have the following
 
 Additionally, the namespace where you are adding the new user must have already have been provisioned through [the new project provisioning process](/provision-new-openshift-project/) and must have one or more administrative users.
 
-## Add users<a name="add-users"></a>
+## Add users
 
 You can add users in one of the following primary roles:
 
@@ -66,13 +66,13 @@ oc get rolebindings
 ```
 For more information on adding users, you can watch [Using Just Ask! to gain access into the BCGov or BCDevops GitHub Organizations](https://www.youtube.com/watch?v=IvdPyx2-qm0) or use [the Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/).
 
-## Request platform access<a name="request-access"></a>
+## Request platform access
 
 **Note**: This process only gives you platform access, not namespace access.
 
 The product owner or a project administrator associated with namespace provisioning makes a request through the [Just Ask! tool](https://just-ask-web-bdec76-prod.apps.silver.devops.gov.bc.ca/).
 
-## Grant namespace access<a name="grant-access"></a>
+## Grant namespace access
 
 Technical leads grant namespace access. For more information, see [Using RBAC to define and apply permissions](https://docs.openshift.com/container-platform/4.9/authentication/using-rbac.html).
 

--- a/src/docs/platform-architecture-reference/platform-storage.md
+++ b/src/docs/platform-architecture-reference/platform-storage.md
@@ -29,11 +29,11 @@ We use several different storage technologies in OpenShift. Currently, we have t
 * **S3 Object Storage**: Object-based storage that is available via a web-based API instead of through a mounted directory. A common implementation of this is the Amazon S3 API. This allows remote access storage over the internet that does not require directly attaching to a running system.
 
 ## On this page
-- [Storage services](#service)
+- [Storage services](#storage-services)
 - [Tools](#tools)
 - [Storage details](#storage-details)
 
-## Storage services<a name="service"></a>
+## Storage services
 
 We have access to the following storage services for the OpenShift platform.
 
@@ -69,7 +69,7 @@ This service replicates data between the two datacenters and the API endpoints a
 
 Object Storage Service is highly fault tolerant and uses erasure coding within the cluster, as well as asynchronous replication and automatic failover to the Calgary data center. The solution also offers configurable object versioning, allowing for file recovery. Due to the high fault tolerance, versioning and redundancy, most teams don't implement additional backups. A recommended design pattern would be to replace the application's Minio storage with the direct integration with the S3 API within the Object Storage Enterprise Services.
 
-## Tools<a name="tools"></a>
+## Tools
 
 You can use tools to manage your persistent storage beyond the features built into OpenShift.
 
@@ -77,7 +77,7 @@ You can use tools to manage your persistent storage beyond the features built in
 
 * **Migrating storage**: Another community supported repository is available to help with migrating data from one PVC to another (moving from one storageClass to another, moving to a larger PVC, etc). The repository is called [StorageMigration](https://github.com/BCDevOps/StorageMigration)
 
-## Storage details<a name="storage-details"></a>
+## Storage details
 
 ### Quotas
 All storage sizes are in GiB and backup quotas default to half the storage size. These quotas can be requested in the [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing) by a project's product owner or technical lead.

--- a/src/docs/platform-architecture-reference/set-up-tcp-connectivity-on-private-cloud-openshift-platform.md
+++ b/src/docs/platform-architecture-reference/set-up-tcp-connectivity-on-private-cloud-openshift-platform.md
@@ -23,11 +23,11 @@ Use this page to learn how to configure direct [transmission control protocol (T
 
 ## On this page
 - [Direct TCP access](#direct-tcp-access)
-- [Set up TCP connectivity in the Silver Cluster](#silver-setup)
-- [Set up TCP connectivity on the Gold Kamloops/Gold Calgary Cross-Cluster](#setup-gold-golddr)
+- [Set up TCP connectivity in the Silver Cluster](#set-up-tcp-connectivity-in-the-silver-cluster)
+- [Set up TCP connectivity on the Gold Kamloops/Gold Calgary Cross-Cluster](#set-up-tcp-connectivity-on-the-gold-kamloopsgold-calgary-cross-cluster)
 - [Troubleshooting](#troubleshooting)
 
-## Direct TCP access<a name="direct-tcp-access"></a>
+## Direct TCP access
 Product teams may enable direct non-HTTPS TCP access to services within their namespaces by creating a TransportServerClaim resource.
 
 This feature is available in all production clusters, including Silver and Gold/GoldDR.
@@ -38,7 +38,7 @@ The project must meet the following requirements:
 - Administrative access to the namespaces
 - `oc` command line tool
 
-## Set up TCP connectivity in the Silver Cluster<a name="silver-setup"></a>
+## Set up TCP connectivity in the Silver Cluster
 Use the Porter Operator to enable direct TCP access to your services in the Silver cluster.
 
 ### Confirm service information
@@ -129,7 +129,7 @@ $ timeout 5 bash -c ">/dev/tcp/142.34.194.68/65555"; echo $?
 ```
 Any return code other than `0` indicates a problem.  If that's the case, inquire about the firewall and go to [Troubleshooting](#troubleshooting).
 
-## Set up TCP connectivity on the Gold Kamloops/Gold Calgary cross-cluster<a name="setup-gold-golddr"></a>
+## Set up TCP connectivity on the Gold Kamloops/Gold Calgary cross-cluster
 The Gold and GoldDR clusters are designed to be used in tandem. Production applications are typically served from the Gold cluster. Deployments in the GoldDR cluster are identical to Gold and are meant to be quickly activated as the live production system if there is a problem with the Gold cluster.
 
 Use the Porter Operator to enable direct TCP access from Gold to GoldDR and vice versa. For example, this may be used for database replication.
@@ -230,7 +230,7 @@ Confirm connectivity from any pod in either cluster. Replace `65555` with the po
 ```
 Any return code other than `0` indicates a problem.  If that's the case, inquire about the firewall and go to [Troubleshooting](#troubleshooting).
 
-## Troubleshooting<a name="troubleshooting"></a>
+## Troubleshooting
 Resolve issues by trying the following:
 * Check the Service name used in the `TransportServerClaim`. It must match the existing Service
 * Make sure that there are pods associated with that Service and that they are operating correctly

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -24,19 +24,19 @@ Find details on the following services or tools you can use as part of your proj
 - [Messaging Common service](#messaging-common-service)
 - [Backup Container](#backup-container)
 - [BC Address Geocoder](#bc-address-geocoder)
-- [Common Document Generation service](#dgen)
+- [Common Document Generation service](#common-document-generation-service)
 - [Common Hosted Email service](#common-hosted-email-service)
 - [Common Services Get Token](#common-services-get-token)
 - [Fathom](#fathom)
 - [go-crond](#go-crond)
 - [Matomo OpenShift](#matomo-openshift)
-- [OWASP ZAP Security Vulnerability Scanning](#owasp-zap)
+- [OWASP ZAP Security Vulnerability Scanning](#owasp-zap-security-vulnerability-scanning)
 - [Pathfinder Single Sign-On (SSO) Keycloak](#pathfinder-single-sign-on-keycloak)
-- [SonarQube in Private Cloud PaaS](#sq-private-cloud)
-- [SonarQube on OpenShift](#sq-openshift)
-- [WeasyPrint HTML to PDF/PNG](#weasyprint)
+- [SonarQube in Private Cloud PaaS](#sonarqube-in-the-bc-gov-private-cloud-paas)
+- [SonarQube on OpenShift](#sonarqube-on-openshift)
+- [WeasyPrint HTML to PDF/PNG](#weasyprint-html-to-pdfpng-microservice)
 
-## Messaging Common service<a name="messaging-common-service"></a>
+## Messaging Common service
 The Common Messaging service (CMSG) is an API for sending messages to internal and external users through SMTP and SMS. You can access the CMSG programmatically through the CMSG-MESSAGING-API. For more information, see the following resources:
 * [GitHub repository](https://github.com/bcgov/nr-messaging-service-showcase)
 * [About the Messaging Common Service](https://developer.gov.bc.ca/Community-Contributed-Content/About-the-Messaging-Common-Service)
@@ -49,7 +49,7 @@ However, you can't currently send SMS content through the CMSG-MESSAGING-API, us
 
 The API supports HTML content. The value of mediaType in the request should be text or HTML to render HTML content in the email.
 
-## Backup Container<a name="backup-container"></a>
+## Backup Container
 
 [Backup Container](https://github.com/BCDevOps/backup-container) is a simple, containerized backup solution used to backup one or more supported databases to a secondary location. The code and documentation was originally pulled from [HETS Project](https://github.com/bcgov/hets).
 
@@ -67,7 +67,7 @@ For more information on Backup Container, see the following pages:
 * [backup-container repository](https://github.com/BCDevOps/backup-container)
 * [jag-cullencommission repository](https://github.com/bcgov/jag-cullencommission/tree/master/openshift)
 
-## BC Address Geocoder<a name="bc-address-geocoder"></a>
+## BC Address Geocoder
 
 The BC Address Geocoder REST API lets you integrate real-time standardization, validation and geocoding of physical addresses into your applications. See [the Data Catalogue](https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service) for information on aspects of the REST API that aren't covered in the OpenAPI definition.
 
@@ -79,7 +79,8 @@ For more information on the BC Address Geocoder, see the following pages:
 * [BC Address Geocoder Developer Guide](https://developer.gov.bc.ca/Community-Contributed-Content/BC-Address-Geocoder-Developer-Guide)
 * [BC Address Geocoder repository](https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#outputSRS)
 
-## Common Document Generation service<a name="dgen"></a>
+## Common Document Generation service
+
 Use the Document Generation service (DGEN) to generate documents using template files that contain field values from a database. Once generated, the completed document is stored in the Document Management Service (DMS) repository where you can view and sign it with an electronic signature. You must access DGEN programmatically through the DGEN-API (`https://api.nrs.gov.bc.ca/dgen-api/`). You can find a description of the API in the [Natural Resource Ministry's (NRM) API Store](https://apistore.nrs.gov.bc.ca/store/apis/info?name=dgen-api&version=v1&provider=admin).
 
 ### Features
@@ -96,38 +97,44 @@ For more information on DGEN, see the following pages:
 * [DGEN Developer's Guide](https://developer.gov.bc.ca/Community-Contributed-Content/DGEN-Developer's-Guide)
 * [Document Generation Showcase](https://github.com/bcgov/document-generation-showcase)
 
-## Common Hosted Email service<a name="common-hosted-email-service"></a>
+## Common Hosted Email service
+
 The Common Hosted Email service is hosted by the `bcgov` organization. For more information on the application, see the following pages:
 * [Common Hosted Email service](https://bcgov.github.io/common-hosted-email-service/app/)
 * [common-hosted-email-service repository](https://github.com/bcgov/common-hosted-email-service)
 
-## Common Services Get Token<a name="common-services-get-token"></a>
+## Common Services Get Token
+
 The Common Services Get Token (also known as GETOK) is a web-based tool for development teams to manage their application's secure access to Common Services. Users can create and deploy service clients instantly to gain access to common service APIs like email notifications, document management or document generation.
 
 For more information, see the following pages:
 * [nr-get-token repository](https://github.com/bcgov/nr-get-token)
 * [Common Services showcase](https://bcgov.github.io/common-service-showcase/)
 
-## Fathom<a name="fathom"></a>
+## Fathom
+
 Fathom analytics provide simple website statistics without tracking or storing personal data. [fathom-openshift](https://github.com/BCDevOps/fathom-openshift) is a set of OpenShift configurations to set up an instance of the Fathom web analytics server.
 
 For more information, see the following pages:
 * [Fathom](https://developer.gov.bc.ca/Community-Contributed-Content/Fathom)
 * [fathom-openshift](https://github.com/BCDevOps/fathom-openshift)
 
-## go-crond<a name="go-crond"></a>
+## go-crond
+
 [go-crond](https://github.com/BCDevOps/go-crond) is a cron daemon written in Go for use in Docker images. For more information, see the following pages:
 * [go-crond](https://developer.gov.bc.ca/Community-Contributed-Content/go-crond)
 * [go-crond repository](https://github.com/BCDevOps/go-crond)
 
-## Matomo OpenShift<a name="matomo-openshift"></a>
+## Matomo OpenShift
+
 Matomo is a comprehensive web analytics server and an alternative to Google Analytics when data ownership and privacy compliance are a concern.
 
 Matomo OpenShift provides a set of OpenShift configurations to set up an instance of the Matomo web analytics server. For more information, see the following pages:
 * [Matomo OpenShift](https://developer.gov.bc.ca/Community-Contributed-Content/Matomo-OpenShift)
 * [Matomo](https://matomo.org/)
 
-## OWASP ZAP Security Vulnerability Scanning<a name="owasp-zap"></a>
+## OWASP ZAP Security Vulnerability Scanning
+
 The OWASP Zed Attack Proxy (ZAP) automatically finds security vulnerabilities in web applications. For more information, see the following pages:
 * [OWASP ZAP Security Vulnerability Scanning](https://developer.gov.bc.ca/Developer-Toy-Box/OWASP-ZAP-Security-Vulnerability-Scanning)
 * [openshift-components](https://github.com/BCDevOps/openshift-components/tree/master/cicd/jenkins-slave-zap)
@@ -143,7 +150,7 @@ The Pathfinder SSO service is built on the foundations of Keycloak/Redhat SSO.
 * [What is Keycloak (our take)](https://github.com/bcgov/sso-keycloak/wiki/What-is-Keycloak-@-BC-Government%3F)
 * [Additional references](https://github.com/bcgov/sso-keycloak/wiki/Useful-References)
 
-## SonarQube in the BC Gov Private Cloud PaaS<a name="sq-private-cloud"></a>
+## SonarQube in the BC Gov Private Cloud PaaS
 
 [SonarQube®](https://www.sonarqube.org/) is an automatic code review tool you can use to detect bugs, vulnerabilities and code smells in your code. It can integrate with your existing workflow to enable continuous code inspection across your project branches and pull requests.
 
@@ -153,7 +160,8 @@ SonarQube is a community-supported service. We also encourage teams to switch to
 
 For more information, see [SonarQube Best Practices](https://developer.gov.bc.ca/Platform-Services-Security/SonarQube-Best-Practices). You can also review the [SonarQube repository](https://github.com/BCDevOps/sonarqube)
 
-## SonarQube on OpenShift<a name="sq-openshift"></a>
+## SonarQube on OpenShift
+
 The [sonarqube repository](https://github.com/BCDevOps/sonarqube) contains all the resources you might need to deploy a SonarQube server instance in a B.C. government OpenShift environment and integrate SonarQube scanning into your Jenkins pipeline.
 
 This work was inspired by the [OpenShift Demos SonarQube for OpenShift](https://github.com/OpenShiftDemos/sonarqube-openshift-docker).
@@ -168,7 +176,8 @@ For information on upgrading plugins, see the following pages:
 
 You can also integrate a [ZAP plugin for SonarQube](https://github.com/OtherDevOpsGene/zap-sonar-plugin).
 
-## WeasyPrint HTML to PDF/PNG Microservice<a name="weasyprint"></a>
+## WeasyPrint HTML to PDF/PNG Microservice
+
 The [docker-weasyprint](https://github.com/BCDevOps/docker-weasyprint) project bundles WeasyPrint into a simple, OpenShift-compatible, HTML to PDF/PNG microservice with a simple REST interface.
 
 For more information, see the following pages:

--- a/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
+++ b/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
@@ -25,16 +25,16 @@ You can also still use Kubernetes Secrets backed by ETCD. It is recommended that
 Non-secrets may be stored in Vault if desired.
 
 ## On this page
-- [Features and Functions](#features-and-functions)
-- [Eligibility and Prerequisites](#eligibility-and-prerequisites)
-- [How to Request](#how-to-request)
+- [Features and functions](#features-and-functions)
+- [Eligibility and prerequisites](#eligibility-and-prerequisites)
+- [How to request access](#how-to-request-access)
 - [Availability](#availability)
 - [How do I get help?](#how-do-i-get-help)
 - [What does it cost?](#what-does-it-cost)
-- [Support Roles, Processes, Communications (platform ops)](#support)
-- [Service Delivery](#service-delivery)
+- [Support roles, processes, communications (platform operations)](#support-roles-processes-communications-platform-operations)
+- [Service delivery](#service-delivery)
 
-## Features and functions <a name="features-and-functions"></a>
+## Features and functions
 
 Users of this service gain access to the following:
 
@@ -55,20 +55,20 @@ All secrets in Vault have a lease associated with them. At the end of the lease,
 ### Revocation:
 Vault has built-in support for secret revocation. Vault can revoke not only single secrets, but a tree of secrets, for example all secrets read by a specific user, or all secrets of a particular type. Revocation assists in key rolling as well as locking down systems in the case of an intrusion.
 
-## Eligibility and prerequisites <a name="eligibility-and-prerequisites"></a>
+## Eligibility and prerequisites
 
 Your team is provisioned a Vault service account for each environment (dev, test, prod, and tools) through the automation backing the [Platform Services Registry](https://registry.developer.gov.bc.ca/public-landing). Each ProjectSet created in the registry can have up to two technical contacts associated with it. These technical contacts are given write access to Vault and can manage secrets within a ProjectSet's two mount points (nonprod, prod).
 
-## How to request access<a name="how-to-request"></a>
+## How to request access
 You don’t need to request access to Vault. If you have a project set, you have at least one technical contact who can access Vault through the CLI or UI, and you have a Kubernetes Service Account associated with your project set's Vault Mount Points in each namespace environment. (dev, test, prod, and tools).
 
 Service Accounts take the form of `licensePlate-vault`
 
-## Availability <a name="availability"></a>
+## Availability
 
 The Vault Secrets Management tool is deployed in a high-availability configuration within the highly available Gold clusters in OpenShift. This service is available 24/7 with best effort to restart failed systems.
 
-## How do I get help? <a name="help"></a>
+## How do I get help?
 
 The best source of help is the vibrant community of product teams using Vault for their projects.
 
@@ -76,11 +76,11 @@ You can find this highly talented and knowledgeable group in the [#devops-vault 
 
 For help beyond this contact one of the Vault administrators via the [#devops-sos channel on Rocket.Chat](https://chat.developer.gov.bc.ca/channel/devops-sos).
 
-## What does it cost? <a name="what-does-it-cost"></a>
+## What does it cost?
 
 There is no charge for this service.
 
-## Support roles, processes, communications (platform operations) <a name="support"></a>
+## Support roles, processes, communications (platform operations)
 
 The team supporting this service administers the Vault application and its supporting services.
 
@@ -92,7 +92,7 @@ For cluster wide service notifications that may impact Vault monitor, use the [#
 
 For teams without Rocket.Chat access or to escalate a question or concern, contact us by email at [PlatformServicesTeam@gov.bc.ca](mailto:PlatformServicesTeam@gov.bc.ca). 
 
-## Service delivery <a name="service-delivery"></a>
+## Service delivery
 
 ### Request workflows
 

--- a/src/docs/training-and-learning/training-from-the-platform-services-team.md
+++ b/src/docs/training-and-learning/training-from-the-platform-services-team.md
@@ -17,10 +17,12 @@ content_owner: Olena Mitovska
 
 sort_order: 1
 ---
+
 # Training from the Platform Services team
+
 Learning how to build in OpenShift can be hard. We’ve put together a number of resources to help.
 
-## OpenShift 101 and 201 <a name="openshift101201"></a>
+## OpenShift 101 and 201
 
 The BC Gov Provate Cloud PaaS OpenShift 101 and 201 courses include a theory 'workshop' component, and a practical series of 'lab exercises'. OpenShift 101 is recommended for all new teams joining the platform. OpenShift 201 is a more advanced course for platform users who want to advance their skills in OpenShift.
 
@@ -28,39 +30,39 @@ If the courses fill up, email PlatformServicesTeam@gov.bc.ca - preference is giv
 
 [Register for an OpenShift course](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/platform-training-and-resources/).
  
- ## Video resources <a name="video"></a>
+ ## Video resources
 
 The videos below can also be found on this [YouTube playlist](https://www.youtube.com/playlist?list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
- - [Reusable Front-End UI Components for BC Gov-themed web applications](https://www.youtube.com/watch?v=eFi5QJo2hgo&t=4s)
+- [Reusable Front-End UI Components for BC Gov-themed web applications](https://www.youtube.com/watch?v=eFi5QJo2hgo&t=4s)
 
- - [PodDisruptionBudget Setting in Application Configuration in OpenShift](https://www.youtube.com/watch?v=0AGZ5no6-yo)
+- [PodDisruptionBudget Setting in Application Configuration in OpenShift](https://www.youtube.com/watch?v=0AGZ5no6-yo)
 
- - [Introduction into GitOps and ArgoCD](https://www.youtube.com/watch?v=-Tkqe0lRuE0)
+- [Introduction into GitOps and ArgoCD](https://www.youtube.com/watch?v=-Tkqe0lRuE0)
 
- - [How to get started with GitHub Actions pipeline templates](https://www.youtube.com/watch?v=spUAx_ADhOY)
+- [How to get started with GitHub Actions pipeline templates](https://www.youtube.com/watch?v=spUAx_ADhOY)
 
- - [How to get started with OpenShift Pipelines (Tekton) templates](https://www.youtube.com/watch?v=aO6tLFqstQk)
+- [How to get started with OpenShift Pipelines (Tekton) templates](https://www.youtube.com/watch?v=aO6tLFqstQk)
 
- - [How to tune resources for your Jenkins instance](https://www.youtube.com/watch?v=npMbAtJZSO0)
+- [How to tune resources for your Jenkins instance](https://www.youtube.com/watch?v=npMbAtJZSO0)
 
- - [How to quickstart with Kubernetes Network Policies (KNPs) to enable network connectivity in your new application](https://www.youtube.com/watch?v=qOoIbp9ZZY0)
+- [How to quickstart with Kubernetes Network Policies (KNPs) to enable network connectivity in your new application](https://www.youtube.com/watch?v=qOoIbp9ZZY0)
 
- - [How to build a simple resource usage monitoring dashboard with Sysdig](https://www.youtube.com/watch?v=W9xM5rd9CaQ)
+- [How to build a simple resource usage monitoring dashboard with Sysdig](https://www.youtube.com/watch?v=W9xM5rd9CaQ)
 
- - [OpenShift 101 Source to Image (S2I) Build](https://youtu.be/uTnBWfG-3Ns)
+- [OpenShift 101 Source to Image (S2I) Build](https://youtu.be/uTnBWfG-3Ns)
 
- - [Getting started with the Sysdig and using it to monitor application resource utilization](https://youtu.be/wZrOdxlc_2c)
+- [Getting started with the Sysdig and using it to monitor application resource utilization](https://youtu.be/wZrOdxlc_2c)
 
- - [Horizontal Pod Autoscaling and Vertical Pod Autoscaling for Resource Management In OpenShift](https://youtu.be/nZMtJRQR3jY)
+- [Horizontal Pod Autoscaling and Vertical Pod Autoscaling for Resource Management In OpenShift](https://youtu.be/nZMtJRQR3jY)
  
- - [App Migration from OpenShift On-prem to ARO](https://youtu.be/i-auqEUcR5U)
+- [App Migration from OpenShift On-prem to ARO](https://youtu.be/i-auqEUcR5U)
 
- - [Reusable Front-End REACT and Vue Component Library for BC Gov Web Apps](https://www.youtube.com/watch?v=eFi5QJo2hgo&list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg&index=2&t=21s)
+- [Reusable Front-End React and Vue Component Library for BC Gov Web Apps](https://www.youtube.com/watch?v=eFi5QJo2hgo&list=PL9CV_8JBQHiorxwU-2nA8aqM4KTzdCnfg&index=2&t=21s)
 
- - [Four Golden Signals for App Monitoring](https://youtu.be/W9xM5rd9CaQ)
+- [Four Golden Signals for App Monitoring](https://youtu.be/W9xM5rd9CaQ)
 
 - [Namespace provisioning in OpenShift 4 using GitOps approach](https://youtu.be/5aSon_DVbRM) 
 

--- a/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/src/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -20,7 +20,7 @@ sort_order: 1
 
 # BC Government organizations in GitHub
 
-BC Gov Private Cloud PaaS product teams use <a href="https://github.com" target="_blank">GitHub</a> to host open code and repositories. Using GitHub you can:
+BC Gov Private Cloud PaaS product teams use [GitHub](https://github.com) to host open code and repositories. Using GitHub you can:
 * Share and control code versions
 * Use tools for team and project management
 * Track issues
@@ -30,15 +30,15 @@ BC Gov Private Cloud PaaS product teams use <a href="https://github.com" target=
 The main organization the B.C. government owns in GitHub is [bcgov](https://github.com/bcgov) where we store all open-source code developed by B.C. government teams. The `bcgov` organization includes close to 1000 repositories maintained by the B.C. government developer community.
 
 ## On this page
-- [Working in the open](#work-in-open)
-- [Organizations in GitHub](#gov-orgs)
-- [Ministry-specific private organizations in GitHub Enterprise](#ministry-private-orgs)
+- [Working in the open](#working-in-the-open)
+- [Organizations in GitHub](#organizations-in-github)
+- [Ministry-specific private organizations in GitHub Enterprise](#ministry-specific-private-organizations-in-github-enterprise)
 
-## Working in the open<a name="work-in-open"></a>
+## Working in the open
 
 The [Digital Principles for the Government of B.C.](https://digital.gov.bc.ca/resources/digital-principles) urge product teams to work in the open as outlined in principle five. GitHub is the leading platform for open-source projects. It allows the Province to collaborate with the open-source community to build software, support innovation and save time and money.
 
-## Organizations in GitHub<a name="gov-orgs"></a>
+## Organizations in GitHub
 
 The Province owns several GitHub organizations, which are described below.
 
@@ -62,7 +62,7 @@ Your product team can only have a **permanent**, private repository in `bcgov-c`
 * Only the Platform Services team can create repositories in this organization.
 * GitHub application integration (for example, SonarCloud testing) needs to be individually enabled for each repository. The Platform Services team approves all third-party application integration in all B.C. government organizations.
 
-## Ministry-specific private organizations in GitHub Enterprise<a name="ministry-private-orgs"></a>
+## Ministry-specific private organizations in GitHub Enterprise
 
 Ministry-specific **private** organizations must be linked to the B.C. government's Enterprise account (user licenses are required for the members of these organizations).
 

--- a/src/docs/use-github-in-bcgov/evaluate-open-source-content.md
+++ b/src/docs/use-github-in-bcgov/evaluate-open-source-content.md
@@ -27,7 +27,7 @@ For more information on approval requirements, see [Start working in the BC Gov 
 ## On this page
 - [Privacy](#privacy)
 - [Copyright](#copyright)
-- [Legal, contractual, or policy](#legal-contractual-policy)
+- [Legal, contractual, or policy](#legal-contractual-or-policy-constraints)
 - [Security](#security)
 
 These guidelines help you make sure that there are no restrictions to using the material publicly. Restrictions may be due to one of the following concerns:
@@ -38,13 +38,13 @@ These guidelines help you make sure that there are no restrictions to using the 
 
 Evaluate the content you wish to use before posting the material in a GitHub repository.
 
-## Privacy<a name="privacy"></a>
+## Privacy
 
 Make sure that the content is free of personal information that may directly identify an individual (for example, name, phone number, photo, address, driver's licence number or any similar identification number).
 
 Ministries may contact Knowledge and Information Services to assist in privacy assessments.
 
-## Copyright<a name="copyright"></a>
+## Copyright
 Make sure to meet the following requirements:
 - Content is created solely by B.C. government employees
 - Content is fully owned by the B.C. government and doesn't contain any third-party content. Collect copies of any contracts related to the content for review with the [Intellectual Property Program (IPP)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program)
@@ -53,13 +53,13 @@ Make sure to meet the following requirements:
 
 Ministries  **must**  contact the IPP to assist in this assessment. Any legal review or legal advice is provided by the Legal Services Branch.
 
-## Legal, contractual or policy constraints<a name="legal-contractual-policy"></a>
+## Legal, contractual or policy constraints
 
 Make sure that the public release and use of the content is permitted under law, contract or policy. For example, make sure that there are no relevant legal, contractual or policy restrictions or limitations.
 
 If there are legal, contractual or policy restrictions or limitations on the content, you must address them before you can use the content.
 
-## Security<a name="security"></a>
+## Security
 
 Contact your [Ministry Information Security Officer (MISO)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/information-security-policy-and-guidelines/role-of-miso) to make sure that all necessary security controls have been implemented.
 

--- a/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
+++ b/src/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
@@ -25,17 +25,17 @@ All code by B.C. government teams should be open source by default. If you have 
 For more information on our GitHub organizations and their uses, see [B.C. government organizations in GitHub](/bc-government-organizations-in-github/).
 
 ## On this page
-- [Benefits of a GitHub Enterprise user licence](#benefits)
-- [Enterprise account ownership](#ownership)
-- [Request GitHub Enterprise user licences](#request)
-- [Access the GitHub Enterprise account](#access)
-- [Pay for the GitHub Enterprise user licences](#payment)
+- [Benefits of a GitHub Enterprise user licence](#benefits-of-a-github-enterprise-user-licence)
+- [Enterprise account ownership](#enterprise-account-ownership)
+- [Request GitHub Enterprise user licences](#request-github-enterprise-user-licences)
+- [Access the GitHub Enterprise account](#access-the-github-enterprise-account)
+- [Pay for the GitHub Enterprise user licences](#pay-for-the-github-enterprise-user-licences)
 
-## Benefits of a GitHub Enterprise user licence<a name="benefits"></a>
+## Benefits of a GitHub Enterprise user licence
 
 The enterprise user licence offers various features over the Free and Teams version. To find out more on the differences in features and pricing, see [Pricing](https://github.com/pricing).
 
-## Enterprise account ownership<a name="ownership"></a>
+## Enterprise account ownership
 
 The GitHub Enterprise account is owned by OCIO and managed by the Platform Services team. Ministries own GitHub organizations linked to the B.C. government’s GitHub Enterprise accounts and the private repositories within their organizations.  
 
@@ -46,7 +46,7 @@ When your private organization is linked to the GitHub Enterprise account certai
 * GitHub Actions is enabled for all
 * Code Dependency Insights is enabled for all organizations linked to the GitHub Enterprise account
 
-## Request GitHub Enterprise user licences<a name="request"></a>
+## Request GitHub Enterprise user licences
 
 Contact Software Central Management at SoftwareCentral.Management@gov.bc.ca and cc Dean Picton (Dean.Picton@gov.bc.ca). Use the subject line "GitHub Enterprise Request" and send the following information:  
 
@@ -56,7 +56,7 @@ Contact Software Central Management at SoftwareCentral.Management@gov.bc.ca and 
 
 * Number of user licenses needed. If you're transferring a GitHub organization to Enterprise, request as many user licenses as you have organization members.
 
-## Access the GitHub Enterprise account<a name="access"></a>
+## Access the GitHub Enterprise account
 
 Each ministry has GitHub administrators that manage user licences purchased by the ministry and assign individual users to the licences. All license management and licence-to-user assignment must go through ministry account administrators.   
 
@@ -68,7 +68,7 @@ Each ministry has GitHub administrators that manage user licences purchased by t
 
 These users have access to all features available in GitHub Enterprise within their private organization.
 
-## Pay for the GitHub Enterprise user licences<a name="payment"></a>
+## Pay for the GitHub Enterprise user licences
 
 Software Central Management handles your purchase order, with billing back to your expense authority. The ministry is billed monthly for the GitHub Enterprise user licenses until Software Central gets a request asking to cancel the user licenses.
 

--- a/src/docs/use-github-in-bcgov/license-your-github-repository.md
+++ b/src/docs/use-github-in-bcgov/license-your-github-repository.md
@@ -22,12 +22,12 @@ sort_order: 9
 Licences help you manage and share intellectual property for code and materials on GitHub. If you want to consume, share or contribute to anything in GitHub, you have to understand requirements associated with the relevant licence.
 
 ## On this page
-- [Licence guidelines](#guidelines)
-- [Authority to license](#authority-licence)
-- [Choose a licence](#choose-licence)
-- [Apply the licence to your project](#apply-licence)
+- [Licence guidelines](#licence-guidelines)
+- [Authority to license](#authority-to-license)
+- [Choose a licence](#choose-a-licence)
+- [Apply the licence to your project](#apply-the-licence-to-your-project)
 
-## Licence guidelines<a name="guidelines"></a>
+## Licence guidelines
 
 Note if the licence attached to material restricts modification or redistribution of the content. If a licence isn't attached to content, assume that it's "all rights reserved" and can't be used without the express permission of the copyright owner.
 
@@ -41,7 +41,7 @@ If want to initiate a project or release previously created materials, be aware 
 
 The Province’s intellectual property rights must be, at a minimum, equal to the rights under which the content will be licensed to third parties. Four open licences are approved for use that likely cover the majority of projects coming forward:
 
-## Authority to license<a name="authority-licence"></a>
+## Authority to license
 
 The Intellectual Property Program (IPP) must approve licences of B.C. government owned intellectual property unless a ministry has either specific legislative authority or Treasury Board approval that lets them license the intellectual property rights of the Province to third parties. When IPP is the authority for the licensing, you work with IPP to find the best fit to meet the licensing needs of the project.
 
@@ -62,7 +62,7 @@ Use these licences, as they are widely accepted, and follow a consistent approac
 
 If your project is better suited to a different licence, discuss your requirements with the IPP. They can help answer your questions and advise on your need for any other legal or risk management advice.
 
-## Choose a licence<a name="choose-licence"></a>
+## Choose a licence
 
 The following overview provided is intended to inform, not replace, the licensing review for each project. If you think you need to engage with the Intellectual Property Program, send a request to the IPP Manager
 
@@ -72,7 +72,7 @@ If your project is related to a community that typically uses a different licenc
 
 ![A flowchart to outline code preparation for GitHub](../../images/github-code-preparation-chart.png)
 
-## Apply the licence to your project<a name="apply-licence"></a>
+## Apply the licence to your project
 
 Place the licence file for your project in the repository before you do anything else. The default license for code repositories is Apache 2.0.
 

--- a/src/docs/use-github-in-bcgov/required-pages-for-github-repository.md
+++ b/src/docs/use-github-in-bcgov/required-pages-for-github-repository.md
@@ -17,7 +17,9 @@ content_owner: Olena Mitovska
 
 sort_order: 7
 ---
+
 # Required pages for a GitHub repository
+
 When you create a repository in the `bcgov` organization, add the following markdown files:
 - License
 - README
@@ -28,14 +30,14 @@ When you create a repository in the `bcgov` organization, add the following mark
 - [Licence](#licence)
 - [ReadMe](#readme)
 - [Code of conduct](#code-of-conduct)
-- [Contribution guidelines](#contribution)
+- [Contribution guidelines](#contribution-guidelines)
 
-## Licence<a name="licence"></a>
+## Licence
 Choose a licence and place a licence file in your repository before you do anything else. For important information on licences, see [License your GitHub repository](/license-your-github-repository/).
 
 Depending on the licence you choose, add boilerplate text for the applicable licence to your README file.
 
-## ReadMe<a name="readme"></a>
+## ReadMe
 GitHub has extensive documentation on how to create a good README file for your repository. Follow these guidelines when you create your README.
 
 For more information, see [About READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes).
@@ -46,12 +48,12 @@ Make sure to include the following:
 - Depending on your licence, boilerplate text for the applicable licence. For more information, see [License your GitHub repository](/license-your-github-repository/)
 - A link to your code of conduct file
 
-## Code of conduct<a name="code-of-conduct"></a>
+## Code of conduct
 Write a clear code of conduct to ensure contributors to your project foster an open and welcoming environment.
 
 Two good starting points to create a code of conduct for your project are the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) and GitHub's guidelines on [healthy contributions](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions).
 
-## Contribution guidelines<a name="contribution"></a>
+## Contribution guidelines
 Write concise and clear contribution guidelines. Let potential contributors know how you prefer they work on projects and give them the correct information to do so.
 
 For example, if you prefer contributors fork repositories and [submit pull requests](https://help.github.com/articles/using-pull-requests/), provide links to the applicable documentation.

--- a/src/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
+++ b/src/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
@@ -23,9 +23,9 @@ sort_order: 8
 If you plan to share code developed by or for the B.C. government, [evaluate the content](/evaluate-open-source-content/) and get approval from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
 
 ## On this page
-- [Post existing code or projects](#post-existing)
-- [Initiate new code or projects](#initiate)
-- [Contribute to outside code or projects](#contribute)
+- [Post existing code or projects](#post-existing-code-or-projects)
+- [Initiate new code or projects](#initiate-new-code-or-projects)
+- [Contribute to outside code or projects](#contribute-to-outside-code-or-projects)
 
 The B.C. government follows the Open Development Standard, which outlines the following:
 * [Minimum content requirements](/required-pages-for-github-repository/): README, contributing file, code of conduct and license
@@ -34,7 +34,7 @@ The B.C. government follows the Open Development Standard, which outlines the fo
 
 Generally, GitHub projects fall under one of the three following categories, with different key considerations depending on the type.
 
-## Post existing code or projects<a name="post-existing"></a>
+## Post existing code or projects
 
 Projects like this follow two basic approaches, but can vary.
 
@@ -60,7 +60,7 @@ In both cases, the basic steps to release the code are similar, while the implic
 
 If you are intending to maintain an active project, make sure to establish the appropriate processes and terms to manage contributions.
 
-## Initiate new code or projects<a name="initiate"></a>
+## Initiate new code or projects
 
 These are projects that you want to manage as an open-source, collaborative project.
 
@@ -69,7 +69,7 @@ These are projects that you want to manage as an open-source, collaborative proj
 - [Create the minimum required content](/required-pages-for-github-repository/).
 - Add a [Contributor Code of Conduct](http://contributor-covenant.org/) to your repository. This document lets people know that all are welcome to contribute, and that all who contribute pledge to make participation in the project a harassment-free experience for everyone. Include a code of conduct and provide a contact method (in the placeholder) so that people know how to report violations. Introduce the code of conduct in your `readme.md`.
 
-## Contribute to outside code or projects<a name="contribute"></a>
+## Contribute to outside code or projects
 
 There may be circumstances where it's useful and appropriate for employees to contribute to non-B.C. government repositories as a part of their work. In these cases, consider the following:
 

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -120,6 +120,10 @@ Also, when placing images in the documents, make sure they have a relative link 
 
 Use the **On this page** section as a simple table of contents. See this section on [Anchor links](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/links).
 
+There is no need to manually add anchor links (like `<a name="example"></a>`) in order to create the table of contents. Both GitHub and Gatsby automatically generate IDs for all levels of headings using the same rules. When creating the ID, headings are set to lower-case, whitespace is replaced with dashes, and special characters are removed.
+
+Not sure what the ID for your new heading will be? Add the heading to the document and view it on GitHub. Mouse-over the heading and click the link icon to the left of the heading to move the browser to that anchor. Grab the ID from the URL bar.
+
 ### People
 
 Avoid using people's names in documentation. There are many good reasons for this:

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -8,16 +8,16 @@ This is the paragraph I'm changing.
 Also, reference the [style and terminology guide](https://docs.google.com/spreadsheets/d/1uNueaRQSQ7ssrMF8zo9YQUJeHj7dL307rLww2hzGuiE/edit#gid=0) that's still in development for more specific rules. Keep in mind that the style guide tracks rules for granular usage of terms or formatting and is built around decisions made during the writing process by writers and stakeholders.
 
 ## On this page
-- [Formatting](#format)
-- [Tone and voice](#tone)
-- [Audience](#audience)
-- [Page structure and elements](#structure)
+- [Formatting](#formatting)
+- [Tone and voice](#tone-and-voice)
+- [Audience](#audience-and-perspective)
+- [Page structure and elements](#page-structure-and-elements)
 - [Accessibility](#accessibility)
-- [Writing step-by-step instructions](#instructions)
+- [Writing step-by-step instructions](#writing-step-by-step-instructions)
 - [Metadata](#metadata)
 - [Resources](#resources)
 
-## Formatting<a name="format"></a>
+## Formatting
 
 Use the following guidelines for basic formatting.
 
@@ -35,7 +35,7 @@ Use the following guidelines for basic formatting.
 
   `code example that seriously rocks`
 
-## Tone and voice<a name="tone"></a>
+## Tone and voice
 
 The [Grammar, spelling and tone](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/grammar-spelling-tone) section of the Web Style Guide thoroughly covers tone and voice, but here are the most important points to keep in mind:
 
@@ -53,7 +53,7 @@ The [Grammar, spelling and tone](https://www2.gov.bc.ca/gov/content/governments/
 
 - [Don't use Latin abbreviations](https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/) (e.g., i.e., etc.). They're not always familiar to non-native English speakers, they don't always get read correctly by screen readers, and people don't speak Latin. Write around them or use the full term.
 
-## Audience and perspective<a name="audience"></a>
+## Audience and perspective
 The audience for the technical documentation generally has a high-level of devops knowledge and there are also other avenues for assistance (for example, RocketChat).
 
 ### Duplicate content
@@ -90,7 +90,7 @@ When linking from Markdown pages in `./src/docs/` to the Cloud WordPress site, u
 ### FAQs
 [Don't write FAQs](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/faqs) or format sections as a question and answer. Just tell the reader what they need to know.
 
-## Page structure and elements<a name="structure"></a>
+## Page structure and elements
 
 ### Titles
 Use a descriptive and specific title. What does the reader do with the page? What specific information do they gain?
@@ -130,11 +130,11 @@ Avoid using people's names in documentation. There are many good reasons for thi
 
 You get the idea. Essentially, when you avoid using their name, it means you avoid questions and also don't have to go back and update it later. Use their position or reference more general means of contact. For example, a RocketChat channel or a team email.
 
-## Accessibility<a name="accessibility"></a>
+## Accessibility
 
 Use the [BC Government's guidelines and tools](https://www2.gov.bc.ca/gov/content/home/accessible-government/toolkit) to ensure your work is accessible and inclusive.
 
-## Writing step-by-step instructions<a name="instructions"></a>
+## Writing step-by-step instructions
 Occasionally, you'll have to write procedures. Find some of the most useful tips below but also check out [Microsoft's best practices for instructions](https://docs.microsoft.com/en-us/style-guide/procedures-instructions/). It's a great crash course.
 
 - Use numbered and bullet lists but not multi-level lists. Don't write single-item lists.
@@ -149,7 +149,7 @@ Occasionally, you'll have to write procedures. Find some of the most useful tips
 
 - When you can, familiarize yourself with tools and programs so you can reference the UI accurately. However, tell the reader what they need to do, rather than getting too specific on the UI. Remember that the audience is already quite technical.
 
-## Metadata<a name="metadata"></a>
+## Metadata
 
 We use YAML frontmatter in our Markdown files to add metadata to our documents. These fields are necessary to generate pages properly. Track the metadata in the fields of each page based on these descriptions:
 
@@ -179,7 +179,7 @@ It's important to track relevant keywords for each page and to refine them as th
 
 - "Metadata is information about information. Metadata describes the content and taxonomy organizes the content. Taxonomical terms should be stored as metadata, but metadata itself isn’t taxonomy."
 
-## Resources<a name="resources"></a>
+## Resources
 
 - [BC Government: Writing for the web](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide): My all-purpose style source for this specific project.
 

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -54,7 +54,7 @@ The [Grammar, spelling and tone](https://www2.gov.bc.ca/gov/content/governments/
 - [Don't use Latin abbreviations](https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/) (e.g., i.e., etc.). They're not always familiar to non-native English speakers, they don't always get read correctly by screen readers, and people don't speak Latin. Write around them or use the full term.
 
 ## Audience and perspective
-The audience for the technical documentation generally has a high-level of devops knowledge and there are also other avenues for assistance (for example, RocketChat).
+The audience for the technical documentation generally has a high-level of devops knowledge and there are also other avenues for assistance (for example, Rocket.Chat).
 
 ### Duplicate content
 Don't duplicate content across pages. Remember the principle of **one topic = one page**. Rather than duplicating content, link to content that's needed. There's a couple solid reasons for this:
@@ -79,7 +79,7 @@ The resources below have more information. They are concerned largely with forms
 - [One thing per page principle](https://mgearon.com/ux/one-thing-per-page-principle/)
 
 ### Linking strategy
-[The Nielson Norman Group has extensive and thorough guidance on writing excellent hyperlinks](https://www.nngroup.com/articles/writing-links/).
+[The Nielsen Norman Group has extensive and thorough guidance on writing excellent hyperlinks](https://www.nngroup.com/articles/writing-links/).
 
 Make sure that the link to an external page is descriptive. The user should know (or have a good idea) where the link is going to take them before they click it.
 
@@ -128,7 +128,7 @@ Avoid using people's names in documentation. There are many good reasons for thi
 - They may have left the position or changed positions
 - Organizational contact methods or means may have changed
 
-You get the idea. Essentially, when you avoid using their name, it means you avoid questions and also don't have to go back and update it later. Use their position or reference more general means of contact. For example, a RocketChat channel or a team email.
+You get the idea. Essentially, when you avoid using their name, it means you avoid questions and also don't have to go back and update it later. Use their position or reference more general means of contact. For example, a Rocket.Chat channel or a team email.
 
 ## Accessibility
 


### PR DESCRIPTION
Closes #113.

Since there is no need to manually add anchor links in either Gatsby or GitHub, and because they have proven error-prone, I've removed all of them from the Tech Docs site in this pull request. I've updated all "On this page" table of contents components to point to the automatically generated heading IDs, which are identical in GitHub and Gatsby.

I've also updated the Tech Docs Writing Guide to include guidance on how heading IDs are created, and how to grab them from GitHub if the author is unsure of what the generated ID will be. (7921138f66de106a8306bb51e02c2028f846a406)