### PR TITLE
No ANSI color codes in Gatsby production build logs

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -12,9 +12,9 @@ WORKDIR /app
 COPY package*.json .
 RUN npm install
 
-# Copy remaining files, run build script
+# Copy remaining files, run build script with no ANSI color codes
 COPY . .
-RUN ["npm", "run", "build"]
+RUN NO_COLOR=true npm run build
 
 # Production stage
 FROM nginxinc/nginx-unprivileged:1.20 as production-stage


### PR DESCRIPTION
This PR updates the `./Dockerfile.prod` file that's used to create production-ready builds of the application by running the `build` command from Gatsby. 

Without the `NO_COLOR=true` environment variable, ANSI color codes pollute the logs in OpenShift like this:

```
[2K[1A[2K[Gsuccess load plugins - 27.698s

[2K[1A[2K[GonPreInit for gatsby-remark-string-replace plugin

[2K[1A[2K[Gsuccess onPreInit - 0.101s

[2K[1A[2K[Gsuccess initialize cache - 1.304s

[2K[1A[2K[Gsuccess copy gatsby files - 3.188s

[2K[1A[2K[Gverbose Attaching functions to development server

[2K[1A[2K[Gsuccess Compiling Gatsby Functions - 4.806s

[2K[1A[2K[Gsuccess onPreBootstrap - 5.097s
```

This change will make the logs less noisy like this:

```
success onPreInit - 0.006s
success initialize cache - 0.053s
success copy gatsby files - 0.174s
verbose Attaching functions to development server
success Compiling Gatsby Functions - 0.203s
success onPreBootstrap - 0.217s
```