### PR TITLE
update sysdig doc link

### DIFF
--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -37,7 +37,7 @@ Before asking for more quota for your project set, check if the application is f
 
 Use Sysdig to monitor your application. You can access dashboards that show your application memory, CPU and storage usage.
 
-Before you ask for a quota increase, the Platform Services team wants you to monitor and collect metrics to show how much resource your application uses. For more information, see [Get Started with Sysdig Monitor](https://developer.gov.bc.ca/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring). The documentation has all you need to onboard onto Sysdig and use the default dashboards. If you have any issues onboarding to Sysdig, contact the Platform Services team on the applicable [Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
+Before you ask for a quota increase, the Platform Services team wants you to monitor and collect metrics to show how much resource your application uses. For more information, see [Get Started with Sysdig Monitor](https://beta-docs.developer.gov.bc.ca/sysdig-monitor-onboarding/). The documentation has all you need to onboard onto Sysdig and use the default dashboards. If you have any issues onboarding to Sysdig, contact the Platform Services team on the applicable [Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
 
 ## Request a quota increase
 **Note**: Before you request a quota increase, make sure that your project is using its resources efficiently. The Platform Services team wants to be very confident your project needs more quota before they grant an increase.
@@ -88,7 +88,7 @@ Once the quota increase request is approved, the specified namespaces are upgrad
 Related links:
 * [Resource Management Guidelines](https://github.com/BCDevOps/developer-experience/blob/master/docs/ResourceManagementGuidelines.md)
 * [Application Resource Tuning](https://github.com/BCDevOps/developer-experience/blob/master/docs/resource-tuning-recommendations.md)
-* [Get Started with Sysdig Monitoring](https://developer.gov.bc.ca/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring)
+* [Get Started with Sysdig Monitoring](https://beta-docs.developer.gov.bc.ca/sysdig-monitor-onboarding/)
 * [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
 * [OpenShift 4 Project Registry](https://registry.developer.gov.bc.ca/public-landing)
 * [OpenShift project resource quotas](/openshift-project-resource-quotas/)


### PR DESCRIPTION
someone noticed the link to refer to sysdig documentation is outdated.
