### PR TITLE
NSX Networking page updates

### DIFF
--- a/src/docs/platform-architecture-reference/nsx-networking.md
+++ b/src/docs/platform-architecture-reference/nsx-networking.md
@@ -5,7 +5,7 @@ slug: nsx-networking
 
 description: The new Emerald cluster is running on VMware NSX and leveraging the SDN provided by it. There are several differences from the traditional OCP clusters documented here to assist product teams on getting up to speed.
 
-keywords: NSX, SDN, cluster, SNAT,  openshift
+keywords: NSX, SDN, cluster, SNAT, OpenShift
 
 page_purpose: Educate product teams on the specific requirements for NSX clusters
 

--- a/src/docs/platform-architecture-reference/nsx-networking.md
+++ b/src/docs/platform-architecture-reference/nsx-networking.md
@@ -21,21 +21,21 @@ sort_order:
 # NSX SDN Cluster <!-- omit in toc -->
 
 - [API](#api)
-  - [Web Console](#web-console)
+  - [Web console](#web-console)
 - [Segment](#segment)
 - [SNAT IP](#snat-ip)
 - [NetPol differences](#netpol-differences)
   - [Egress](#egress)
   - [Route access](#route-access)
 - [Vault](#vault)
-- [Forward Proxy](#forward-proxy)
-- [Data Classification](#data-classification)
+- [Forward proxy](#forward-proxy)
+- [Data classification](#data-classification)
 
 ## API
 
 The API for the NSX clusters is still publicly available so that GitHub Actions and other external tools can connect.
 
-### Web Console
+### Web console
 
 The web console is limited to only within government networks. Please connect to the VPN or be on an office network to access the web console.
 
@@ -217,7 +217,7 @@ spec:
     - Egress
 ```
 
-## Forward Proxy
+## Forward proxy
 
 While the `*-tools` namespace has a public SNAT IP and can easily reach the internet, the rest of the namespaces cannot directly connect to the internet.
 
@@ -260,7 +260,7 @@ NO_PROXY=.gov.bc.ca
 
 The URL allowlist for the proxy is shared by the whole /16 subnet. So if you need access to additional URLs, please contact the Ops Team to request a change to the URL list.
 
-## Data Classification
+## Data classification
 
 In `*-tools` namespaces, all pods will be treated as having a `low` data classification, unless labeled otherwise. This is so that build pods, which can't be labeled, are treated properly by the guardrails.
 

--- a/src/docs/platform-architecture-reference/nsx-networking.md
+++ b/src/docs/platform-architecture-reference/nsx-networking.md
@@ -20,6 +20,9 @@ sort_order:
 
 # NSX networking
 
+The new Emerald cluster is running on VMware NSX and leveraging the SDN provided by it. There are several differences from the traditional OCP clusters documented here to assist product teams on getting up to speed with the NSX SDN cluster.
+
+## On this page
 - [API](#api)
   - [Web console](#web-console)
 - [Segment](#segment)

--- a/src/docs/platform-architecture-reference/nsx-networking.md
+++ b/src/docs/platform-architecture-reference/nsx-networking.md
@@ -1,5 +1,5 @@
 ---
-title: NSX Networking 
+title: NSX networking 
 
 slug: nsx-networking
 
@@ -18,7 +18,7 @@ content_owner: Steven Barre
 sort_order: 
 ---
 
-# NSX SDN Cluster <!-- omit in toc -->
+# NSX networking
 
 - [API](#api)
   - [Web console](#web-console)

--- a/src/docs/platform-architecture-reference/nsx-networking.md
+++ b/src/docs/platform-architecture-reference/nsx-networking.md
@@ -269,6 +269,6 @@ In `*-tools` namespaces, all pods will be treated as having a `low` data classif
 
 In all other namespaces, pods MUST have a label of `DataClass` with a value of either `Low`, `Medium`, or `High`. Unlabeled pods will be unable to communicate.
 
-`DataClass=Low` pods can optionally have a label of `Internet-Ingress=DENY` which prevents them from getting access via Routes, but then let's them talk to High Data Class workloads.
+`DataClass=Low` pods can optionally have a label of `Internet-Ingress=DENY` which prevents them from getting access via Routes, but then lets them talk to High Data Class workloads.
 
-You can read more about the [SDN Security Classification Model](https://bcgov.sharepoint.com/:w:/r/teams/04091/Shared%20Documents/SDN/Core%20Documents/SDN%20Security%20Classification%20Model.docx?d=wa10f5e8a5863475a9b6fc46d8b88e18f&csf=1&web=1&e=sZBEAc) on Sharepoint.
+You can read more about the [SDN Security Classification Model](https://bcgov.sharepoint.com/:w:/r/teams/04091/Shared%20Documents/SDN/Core%20Documents/SDN%20Security%20Classification%20Model.docx?d=wa10f5e8a5863475a9b6fc46d8b88e18f&csf=1&web=1&e=sZBEAc) by requesting access on Sharepoint.


### PR DESCRIPTION
This PR updates the new "NSX networking" page to bring it in line with our style:

- Sentence casing for titles
- Page title is sentence-cased and matches H1 heading
- An introductory paragraph is added right after the H1 to better the chances that this appears in search result snippets. This was created using the `description` YAML metadata field, and then using the previous H1 value as a keyword at the end.
- Fix capitalization on "OpenShift"
- For the SharePoint link at the bottom of the page, it requires a user to request access (it's not available to the general public), so I've added a description indicating that. I'm using similar language throughout the site on any link that will not resolve properly without authentication (ex: "(IDIR required)")