### PR TITLE
Description and license updates in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "platform-developer-docs",
   "version": "0.0.1",
-  "description": "Gatbys front-end for display platform developer documentation",
+  "description": "React (Gatsby) front-end for the BC Government Private Cloud as a Service Platform Technical Documentation website",
   "main": "index.js",
   "scripts": {
     "build": "gatsby build --verbose",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/bcgov/platform-developer-docs.git"
   },
   "author": "Tyler Krys <Tyler.Krys@gov.bc.ca>",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bcgov/platform-developer-docs/issues"
   },


### PR DESCRIPTION
This PR updates `package.json` to add an accurate `license` field. This was previously listed with the auto-generated `ISC` entry that you get from using `npm init --y`, which is not correct.

Also updates the `description` field to reflect the proper site name.