### PR TITLE
Add related links section with a link to OpenShift network policies page

### DIFF
--- a/src/docs/platform-architecture-reference/set-up-tcp-connectivity-on-private-cloud-openshift-platform.md
+++ b/src/docs/platform-architecture-reference/set-up-tcp-connectivity-on-private-cloud-openshift-platform.md
@@ -26,6 +26,7 @@ Use this page to learn how to configure direct [transmission control protocol (T
 - [Set up TCP connectivity in the Silver Cluster](#set-up-tcp-connectivity-in-the-silver-cluster)
 - [Set up TCP connectivity on the Gold Kamloops/Gold Calgary Cross-Cluster](#set-up-tcp-connectivity-on-the-gold-kamloopsgold-calgary-cross-cluster)
 - [Troubleshooting](#troubleshooting)
+- [Related links](#related-links)
 
 ## Direct TCP access
 Product teams may enable direct non-HTTPS TCP access to services within their namespaces by creating a TransportServerClaim resource.
@@ -112,6 +113,8 @@ spec:
 Create the `NetworkPolicy` in your namespace:
 
 `$ oc -n yourlicenceplate-dev apply -f allow-from-f5-ingress.yaml`
+
+For more details about how `NetworkPolicy` works in OpenShift, refer to our in-depth [OpenShift network policies](/openshift-network-policies/) page.
 
 ### Test access
 After you create the `TransportServerClaim`, the Porter Operator creates a `TransportServer` in your namespace.
@@ -244,7 +247,5 @@ status:
   port: "65555"
 ```
 
----
-Rewrite sources:
-- new page
----
+## Related links
+- [OpenShift network policies](/openshift-network-policies/)


### PR DESCRIPTION
@NickCorcoran following your NetworkPolicy doc update in #134, could you please take a look at this PR and whether the NetworkPolicy guidance in this file is still correct? This was one that was re-written by Jonathan and Emma earlier this year, but I don't know when it would have been last updated prior to that.

Here's the deployed production page **without** my changes if you'd like to read the current thing in context:
https://beta-docs.developer.gov.bc.ca/set-up-tcp-connectivity-on-private-cloud-openshift-platform/