### PR TITLE
Add Platform Storage link to homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -244,7 +244,9 @@ const IndexPage = ({ location }) => {
           <Card>
             <h3>Platform architecture reference</h3>
             <ul>
-              <li>Platform storage (coming soon)</li>
+              <li>
+                <Link to={"/platform-storage/"}>Platform storage</Link>
+              </li>
               <li>Platform architecture (coming soon)</li>
             </ul>
           </Card>


### PR DESCRIPTION
This pull request adds a link from the site homepage to the [Platform storage](https://beta-docs.developer.gov.bc.ca/platform-storage/) page.

<img width="1840" alt="Platform storage page link in Platform architecture reference tile" src="https://user-images.githubusercontent.com/25143706/195947617-bfbf9981-e32b-4d83-ab5b-7456d16cc71e.png">
