### PR TITLE
Site URL migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a single location for all technical/developer documentation for product teams working on the Private Cloud OpenShift Platform.
 
-Visit the deployed Gatsby site at [beta-docs.developer.gov.bc.ca](https://beta-docs.developer.gov.bc.ca).
+Visit the deployed Gatsby site at [docs.developer.gov.bc.ca](https://docs.developer.gov.bc.ca).
 
 ## Documentation
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
   siteMetadata: {
     title: `Private Cloud as a Service Platform Technical Documentation`,
     description: `Documentation for the BC Government's Private Cloud as a Service Platform.`,
-    siteUrl: `https://beta-docs.developer.gov.bc.ca/`,
+    siteUrl: `https://docs.developer.gov.bc.ca/`,
     googleSiteVerification: `${process.env.GATSBY_GOOGLE_SITE_VERIFICATION}`,
   },
   trailingSlash: `always`,
@@ -21,7 +21,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-canonical-urls`,
       options: {
-        siteUrl: `https://beta-docs.developer.gov.bc.ca/`,
+        siteUrl: `https://docs.developer.gov.bc.ca/`,
         stripQueryString: true,
       },
     },

--- a/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
+++ b/src/docs/automation-and-resiliency/request-quota-increase-for-openshift-project-set.md
@@ -37,7 +37,7 @@ Before asking for more quota for your project set, check if the application is f
 
 Use Sysdig to monitor your application. You can access dashboards that show your application memory, CPU and storage usage.
 
-Before you ask for a quota increase, the Platform Services team wants you to monitor and collect metrics to show how much resource your application uses. For more information, see [Get Started with Sysdig Monitor](https://beta-docs.developer.gov.bc.ca/sysdig-monitor-onboarding/). The documentation has all you need to onboard onto Sysdig and use the default dashboards. If you have any issues onboarding to Sysdig, contact the Platform Services team on the applicable [Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
+Before you ask for a quota increase, the Platform Services team wants you to monitor and collect metrics to show how much resource your application uses. For more information, see [Onboarding to application monitoring with Sysdig](/sysdig-monitor-onboarding/). The documentation has all you need to onboard onto Sysdig and use the default dashboards. If you have any issues onboarding to Sysdig, contact the Platform Services team on the applicable [Rocket.Chat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig).
 
 ## Request a quota increase
 **Note**: Before you request a quota increase, make sure that your project is using its resources efficiently. The Platform Services team wants to be very confident your project needs more quota before they grant an increase.
@@ -88,7 +88,7 @@ Once the quota increase request is approved, the specified namespaces are upgrad
 Related links:
 * [Resource Management Guidelines](https://github.com/BCDevOps/developer-experience/blob/master/docs/ResourceManagementGuidelines.md)
 * [Application Resource Tuning](https://github.com/BCDevOps/developer-experience/blob/master/docs/resource-tuning-recommendations.md)
-* [Get Started with Sysdig Monitoring](https://beta-docs.developer.gov.bc.ca/sysdig-monitor-onboarding/)
+* [Get Started with Sysdig Monitoring](/sysdig-monitor-onboarding/)
 * [devops-sysdig RocketChat channel](https://chat.developer.gov.bc.ca/channel/devops-sysdig)
 * [OpenShift 4 Project Registry](https://registry.developer.gov.bc.ca/public-landing)
 * [OpenShift project resource quotas](/openshift-project-resource-quotas/)

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -50,10 +50,17 @@ const StyledListItem = styled.li`
 `;
 
 const Result = ({ item }) => {
+  // The reason for using crafting our URIs this way is so we can use the Gatsby
+  // <Link> component to link between internal pages for maximum speed.
+  // If we used the the full URLs coming back from Google, we would have to use
+  // <a> tags which causes the browser to navigate, breaking our Single Page App
+  // feel and speed.
+  // See: https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/
+  //
   // This split assumes that item.link is a full URL (not a partial path)
   // and that we are serving the site from a sub-domain (not a sub-directory)
-  // Ex: https://beta-docs.developer.gov.bc.ca/ -> /
-  //     https://beta-docs.developer.gov.bc.ca/login-to-openshift/ -> /login-to-openshift/
+  // Ex: https://docs.developer.gov.bc.ca/ -> /
+  //     https://docs.developer.gov.bc.ca/login-to-openshift/ -> /login-to-openshift/
   function getItemPath(item) {
     return `/${item.link.split("/").slice(3).join("/")}`;
   }

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://beta-docs.developer.gov.bc.ca/sitemap/sitemap-index.xml
+Sitemap: https://docs.developer.gov.bc.ca/sitemap/sitemap-index.xml


### PR DESCRIPTION
This pull request supports BCDevOps/platform-experience [#3210 Migrate Platform Developer Docs search engine results to new URL](https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcdevops/developer-experience/3210).

In order for our new production URL `docs.developer.gov.bc.ca` to replace the current URL `beta-docs.developer.gov.bc.ca`, we need to make the changes included in this PR for search engines to be able to properly index our pages. This is particularly important for our search feature, which uses a Google Programmable Search Engine that takes its results straight from Google's public index. For context, we are currently serving the site from both URLs using two OpenShift routes pointing to the same application instance. After this PR, we will continue serving the site from both URLs to start, and then shift to redirecting traffic from `beta-docs` to `docs` as part of the [Google Search Console site move](https://developers.google.com/search/docs/crawling-indexing/what-is-site-move) procedure.

In f108ee17e6e73e7e7f3f4b0327f5f8799773ed0f, the `gatsby-config.json` file is updated to use the new URL so that all `<meta>` and `<link>` tags in the site `<head>` use the correct URL base. `robots.txt` also gets updated to use the new URL.

2bfad2bf45848833c8c91afc4b89291aaba5e2e1 is a comment update to clarify why we don't use URLs straight from Google in our search result page. Rather, we split the URL that comes back in the search result, and we only use the page path. The page path corresponds to our `slug` metadata field in each Markdown document's frontmatter (see the [Metadata section of the Writing Guide in this repo](2bfad2bf45848833c8c91afc4b89291aaba5e2e1) for more details). Doing it this way gives us the ability to link to pages using Gatsby's internal router, rather than causing genuine page movement in the browser which is far slower.

The site URL is updated in the README in 9146188f7dce715fb9527069a2794d1423c4584d.

659dccf7116ffc36324a68d70eb9a2e15564c745 came up in a search for `beta-docs` in the project. These links are updated to use the internal link format rather than causing browser movement.