### PR TITLE
Remove DevHub links

### DIFF
--- a/src/docs/app-monitoring/check-application-health-after-outage.md
+++ b/src/docs/app-monitoring/check-application-health-after-outage.md
@@ -25,11 +25,12 @@ The OpenShift platform provides a reduced chance of significant unexpected outag
 Still, it's always possible that an outage affects the platform and brings down the applications hosted there. If this happens, speedy recovery is important. Use these guidelines to ensure your application recovers quickly and effectively.
 
 ## On this page
+
 - [Check reporting channels](#check-reporting-channels)
 - [Check your application](#check-your-application)
 - [Keep track of recovery steps](#keep-track-of-recovery-steps)
 
-These guidelines assume that you built your application in a cloud-native, highly resilient manner that makes effective use of the strengths of the OpenShift platform. Make sure you follow our [application resiliency guidelines](https://developer.gov.bc.ca/Developer-Tools/Resiliency-Guidelines). If your application is not cloud-native in its design, it won't benefit from the higher adaptability and recoverability of the platform and may need additional work to recover from a large outage.
+These guidelines assume that you built your application in a cloud-native, highly resilient manner that makes effective use of the strengths of the OpenShift platform. Make sure you follow our [application resiliency guidelines](/app-resiliency-guidelines/). If your application is not cloud-native in its design, it won't benefit from the higher adaptability and recoverability of the platform and may need additional work to recover from a large outage.
 
 ## Check reporting channels
 
@@ -58,11 +59,13 @@ Your pods will likely scale back up on their own. However, it's still a good ide
 - If you're having problems connecting to your application and your pods look healthy, restart them. If that works, that indicates that you may need to build a more complex and robust health check for those pods.
 
 #### Crash Loop Backoff
+
 This error usually indicates a problem with your application: it's repeatedly attempting to boot and failing.
 
 Your application logs should have more information and may provide further information about how to fix this issue. If your application enters CrashLoopBackoff during recovery from an outage, this may indicate that your application is not designed to be fully resilient.
 
 #### Image Pull Backoff
+
 This error generally indicates that the pod is having trouble getting to the image it needs to spin up.
 
 This is usually an indication that there is still a problem with the cluster (check Rocket.Chat or the status page) or with your image (check that it still exists and hasn't been corrupted).
@@ -117,10 +120,14 @@ assignees: caggles, ShellyXueHan
 ```
 
 ---
+
 Related links:
-* [Resiliency Guidelines](https://developer.gov.bc.ca/Developer-Tools/Resiliency-Guidelines)
-* [BCGov Platform Services Status Page](https://status.developer.gov.bc.ca)
+
+- [Application resiliency guidelines](/app-resiliency-guidelines/)
+- [BCGov Platform Services Status Page](https://status.developer.gov.bc.ca)
 
 Rewrite sources:
-* https://github.com/BCDevOps/developer-experience/blob/master/docs/post-outage-checklist.md
+
+- https://github.com/BCDevOps/developer-experience/blob/master/docs/post-outage-checklist.md
+
 ---

--- a/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
+++ b/src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md
@@ -134,7 +134,4 @@ Related resources:
 - [Sysdig User Management Docs](https://docs.sysdig.com/en/manage-teams-and-roles.html)
 - [Sysdig User Roles](https://docs.sysdig.com/en/user-and-team-administration.html)
 
-Rewrite sources:
-* https://developer.gov.bc.ca/Developer-Tools/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring
-
 ---

--- a/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
+++ b/src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
@@ -81,7 +81,4 @@ Related resources:
 - [Sysdig User Management Docs](https://docs.sysdig.com/en/manage-teams-and-roles.html)
 - [Sysdig User Roles](https://docs.sysdig.com/en/user-and-team-administration.html)
 
-Rewrite sources:
-* https://developer.gov.bc.ca/Developer-Tools/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring
-
 ---

--- a/src/docs/app-monitoring/sysdig-monitor-setup-team.md
+++ b/src/docs/app-monitoring/sysdig-monitor-setup-team.md
@@ -196,7 +196,4 @@ Related resources:
 - [Sysdig User Management Docs](https://docs.sysdig.com/en/manage-teams-and-roles.html)
 - [Sysdig User Roles](https://docs.sysdig.com/en/user-and-team-administration.html)
 
-Rewrite sources:
-* https://developer.gov.bc.ca/Developer-Tools/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring
-
 ---

--- a/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
+++ b/src/docs/automation-and-resiliency/app-resiliency-guidelines.md
@@ -106,7 +106,7 @@ Ensure that your pods are not in a `CrashLoopBackOff` state for too long. If the
 
 You may note that this document is pretty vague about the "hows" of these principles. This is because it can vary from application to application, and technology stack to technology stack. The design needs for a highly available chat application are very different from those of a highly available static website.
 
-If you're looking for some general guidance on what high availability options exist in OpenShift, attend our [OpenShift 101] training.(https://developer.gov.bc.ca/ExchangeLab-Course:-Openshift-101) This course covers a number of options, including how to deploy a basic application with high availability.
+If you're looking for some general guidance on what high availability options exist in OpenShift, attend our [OpenShift 101 training](/training-from-the-platform-services-team/). This course covers a number of options, including how to deploy a basic application with high availability.
 
 This is where the community comes in. If you have a highly available application, please feel free to fork this document and add links to examples from your application (along with information about your stack and any explanations you feel might be necessary). The more you reach out to help your fellow developers, the stronger a community we will be.
 
@@ -157,16 +157,12 @@ Related links:
 * [OpenShift: Compute Resources](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#dev-compute-resources)
 * [Horizontal Pod Autoscaler](https://docs.openshift.com/container-platform/3.11/dev_guide/pod_autoscaling.html)
 * [Quality of Service](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#quality-of-service-tiers)
-
 * [Pod Terminations](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
-* [OpenShift 101](https://developer.gov.bc.ca/ExchangeLab-Course:-Openshift-101)
+* [Training from the Platform Services team](/training-from-the-platform-services-team/)
 * [PodDisruptionBudgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
 * [Tools: BCDevOps Backup Container](https://github.com/BCDevOps/backup-container)
 * [Tools: Patroni](https://github.com/BCDevOps/platform-services/tree/master/apps/pgsql/patroni)
 * [Example: Rocketchat](https://github.com/BCDevOps/platform-services/tree/master/apps/rocketchat) - Platform Team
 * [Example: Keycloak](https://github.com/bcgov/ocp-sso) - Platform Team
 * [Example: Devhub](https://github.com/bcgov/devhub-app-web) - Developer Experience
-
-Rewrite sources:
-* https://developer.gov.bc.ca/Developer-Tools/Resiliency-Guidelines
 ---

--- a/src/docs/automation-and-resiliency/application-resource-tuning.md
+++ b/src/docs/automation-and-resiliency/application-resource-tuning.md
@@ -288,7 +288,7 @@ Because memory is incompressible, memory requests and limits should be a little 
 
 ## Related training content
 
-The [OpenShift 101 & 201 training](/training-from-the-platform-services-team/) covers some of the principles of resource tuning. There is a related lab exercise and video demonstration [here](https://github.com/BCDevOps/devops-platform-workshops/blob/master/openshift-201/resource-mgmt.md)
+The [OpenShift 101 & 201 training](/training-from-the-platform-services-team/) covers some of the principles of resource tuning. There is a related [OpenShift 201 resource management lab exercise and video demonstration](https://github.com/BCDevOps/devops-platform-workshops/blob/master/openshift-201/resource-mgmt.md).
 
 ---
 Related links:

--- a/src/docs/automation-and-resiliency/application-resource-tuning.md
+++ b/src/docs/automation-and-resiliency/application-resource-tuning.md
@@ -292,9 +292,5 @@ The [OpenShift 101 & 201 training](/training-from-the-platform-services-team/) c
 
 ---
 Related links:
-*
-
-Rewrite sources:
-* https://developer.gov.bc.ca/Developer-Tools/Resource-Tuning-Recommendations
-* https://bcgov-my.sharepoint.com/:p:/g/personal/olena_mitovska_gov_bc_ca/EXNhWAvKZA5OiR1eMKaug7QBMI-tGiK2FZ_c04p8JI0RGw
+* [Autoscaling with HPA and VPA presentation](https://bcgov-my.sharepoint.com/:p:/g/personal/olena_mitovska_gov_bc_ca/EXNhWAvKZA5OiR1eMKaug7QBMI-tGiK2FZ_c04p8JI0RGw) (IDIR required)
 ---

--- a/src/docs/openshift-projects-and-access/provision-new-openshift-project.md
+++ b/src/docs/openshift-projects-and-access/provision-new-openshift-project.md
@@ -33,8 +33,4 @@ Related links:
 - [Platform Project Registry](https://registry.developer.gov.bc.ca/public-landing)
 - [OnBoarding Guide for BC Gov DevOps Platform](https://docs.google.com/presentation/d/1UcT0b2YTPki_o0et9ZCLKv8vF19eYakJQitU85TAeD4/edit?usp=sharing)
 
-Rewrite sources:
-
-- https://developer.gov.bc.ca/Getting-Started-on-the-DevOps-Platform/How-to-Request-a-New-OpenShift-Project
-
 ---


### PR DESCRIPTION
This pull request removes links to content that has been moved from DevHub (`developer.gov.bc.ca`). Where possible, I have linked to the equivalent internal content.