### PR TITLE
Add new Markdown document template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ In progress (not yet published) documents are located in `./src/drafts`.
 
 Please see [Writing guide for Platform Services technical documentation](./tech-docs-writing-guide.md) for documentation formatting and contribution information.
 
+Start your new document from the [new Markdown document template](./new-markdown-document-template.md).
+
 ## Gatsby application
 
 A Gatsby application for these documents is included in this repository.
 
-### Local Development
+### Local development
 
-Use `Dockerfile.dev` and `docker-compose.dev.yaml` for local development using `gatsby-cli`. If you prefer to run locally without Docker, use the Node.js major version specified in `.nvmrc` and `Dockerfile.dev`.
+#### Set up environment variables
 
 Copy the example `.env` files and fill them with your environment variables:
 
@@ -34,6 +36,28 @@ cp .env.production.example .env.production
 - `GATSBY_GOOGLE_SITE_VERIFICATION` is a meta tag value that ties the Google custom search engine instance to a specific instance of our deployed Gatsby site, allowing us to access information about the pages indexed by Google in [Google Search Console](https://search.google.com/search-console/about)
 - `GATSBY_WORDPRESS_SITE_BASE_URL` is used by `./gatsby-config.js` to allow us to link to our WordPress site in a tokenized fashion from our Markdown documents
 
-### Production Build
+#### Local development using Node/npm
+
+If you prefer to run locally without Docker, use the Node.js major version specified in `.nvmrc` and `Dockerfile.dev` for best results.
+
+1. Install the project dependencies with `npm i`
+2. Install the [Gatsby command line interface](https://www.gatsbyjs.com/docs/reference/gatsby-cli/) with `npm install -g gatsby-cli`
+3. Run the project with Gatsby's [`develop` command](https://www.gatsbyjs.com/docs/reference/gatsby-cli/#develop) using `npm run develop`.
+
+When running in development mode, changes to most files will be automatically reflected in your browser with hot reloading.
+
+#### Local development using Docker
+
+Use `Dockerfile.dev` and `docker-compose.dev.yaml` for local development using `gatsby-cli`.
+
+### Production build
 
 Use `Dockerfile.prod` and `docker-compose.prod.yaml` for a production build served by nginx.
+
+#### Nginx configuration
+
+See `./nginx.conf` for production routing rules.
+
+Caching rules are added here based on Gatsby's [Caching Static Sites documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/caching/).
+
+Redirects can be added here to support changes to content. For example, if a page's slug changes, we can manually add a redirect rule that forwards requests for the old URL to the new content. If a page is removed, a redirect can be added to point to the next most relevant page.

--- a/new-markdown-document-template.md
+++ b/new-markdown-document-template.md
@@ -1,0 +1,55 @@
+---
+# Page title in sentence case, used to generate <title> tag
+title: Page title in sentence case
+
+# Slug is used to generate the page path in the URL. Please use lowercase and separate words with -. Ex: Using `slug: landing-page` will cause the page to appear on the Gatsby site at /landing-page/.
+slug: page-title-in-sentence-case
+
+# A brief, precise description of what a reader will find on the page. Used to generate the <meta name="description"> tag.
+# How to write a good meta description: https://developers.google.com/search/docs/appearance/snippet
+description: A good page description should be unique and succinctly describe the content the user will find on the page.
+
+# Used to generate the <meta property="keywords"> tag. Could be used in the future to group related content.
+keywords: first keyword, second keyword
+
+# This is a more in depth description that isn't used on the rendered page. We can go into more details about why a page needs to exist here, compared to the "description" field which should be for the end-user's benefit.
+page_purpose: The page purpose doesn't appear on the rendered page like the "description" field, but it lets us add context to a document and why it exists.
+
+# Typically, a developer or a technical lead. Not used on the rendered page.
+audience: developer
+
+# Whoever wrote the original draft
+author: Alice
+
+# The subject matter expert of the page. They are responsible for the factual accuracy of the content.
+content_owner: Bob
+
+# A positive integer used to determine the sort order of the page within a navigation menu category. If left blank, the page will be sorted alphabetically at the end of the sorted list within a menu.
+sort_order: 1
+---
+
+# Page title in sentence case
+
+This is introductory text that should go before your table of contents for best search result quality. It might replace your `description` frontmatter field in search results if Google decides it's better.
+
+## On this page
+
+- [First content heading in sentence case](#first-h2-content-heading-in-sentence-case)
+- [Second content heading](#second-h2-content-heading)
+- [Related links](#related-links)
+
+## First H2 content heading in sentence case
+
+This is paragraph text that appears under the first heading.
+
+### First H3 content heading
+
+H3 and lower headings don't necessarily need to appear in your "On this page" table of contents unless you feel like it. Your choice!
+
+## Second H2 content heading
+
+This is paragraph text that appears under the second heading.
+
+## Related links
+
+- [Example.org](https://example.org)

--- a/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
+++ b/src/docs/security-and-privacy-compliance/vault-secrets-management-service.md
@@ -3,11 +3,11 @@ title: Vault secrets management
 
 slug: vault-secrets-management-service
 
-description: describes the vault secrets management service and how it is used in the BC Government
+description: HashiCorp Vault is available for secrets management in the BC Government's OpenShift private cloud platform.
 
 keywords: 
 
-page_purpose: provides infomration relevant to vault sercrets management service to product teams, including description of functions and how to work with this service 
+page_purpose: Provides information relevant to the Vault secrets management service to product teams, including description of functions and how to work with this service.
 
 audience: developer, technical lead
 

--- a/tech-docs-writing-guide.md
+++ b/tech-docs-writing-guide.md
@@ -1,13 +1,13 @@
-
 # Writing guide for Platform Services technical documentation
 
 Use this guide to reference the approach taken to rewrite the Platform Services technical documentation. While this document is a good place to start, it's still alive and breathing and can be modified and improved upon as needed. Don't be shy. Documentation should evolve and improve!
 
-This is the paragraph I'm changing.
-
 Also, reference the [style and terminology guide](https://docs.google.com/spreadsheets/d/1uNueaRQSQ7ssrMF8zo9YQUJeHj7dL307rLww2hzGuiE/edit#gid=0) that's still in development for more specific rules. Keep in mind that the style guide tracks rules for granular usage of terms or formatting and is built around decisions made during the writing process by writers and stakeholders.
 
+When you're ready to start a new document, copy the [new Markdown document template](./new-markdown-document-template.md).
+
 ## On this page
+
 - [Formatting](#formatting)
 - [Tone and voice](#tone-and-voice)
 - [Audience](#audience-and-perspective)
@@ -54,9 +54,11 @@ The [Grammar, spelling and tone](https://www2.gov.bc.ca/gov/content/governments/
 - [Don't use Latin abbreviations](https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/) (e.g., i.e., etc.). They're not always familiar to non-native English speakers, they don't always get read correctly by screen readers, and people don't speak Latin. Write around them or use the full term.
 
 ## Audience and perspective
+
 The audience for the technical documentation generally has a high-level of devops knowledge and there are also other avenues for assistance (for example, Rocket.Chat).
 
 ### Duplicate content
+
 Don't duplicate content across pages. Remember the principle of **one topic = one page**. Rather than duplicating content, link to content that's needed. There's a couple solid reasons for this:
 
 - **Maintenance:** If documentation, information, or processes change, it only needs to be updated in one place. Do your future self a favour.
@@ -79,20 +81,23 @@ The resources below have more information. They are concerned largely with forms
 - [One thing per page principle](https://mgearon.com/ux/one-thing-per-page-principle/)
 
 ### Linking strategy
+
 [The Nielsen Norman Group has extensive and thorough guidance on writing excellent hyperlinks](https://www.nngroup.com/articles/writing-links/).
 
 Make sure that the link to an external page is descriptive. The user should know (or have a good idea) where the link is going to take them before they click it.
 
 When linking from one Markdown page in the `./src/docs/` folder to another, write the link in the form `/<slug of the target page>/`. While these links won't work when viewing the page on GitHub, they will work on the Gatsby site.
 
-When linking from Markdown pages in `./src/docs/` to the Cloud WordPress site, use the token `%WORDPRESS_BASE_URL%` in place of the site address and before the path of the document being linked to, in the form `%WORDPRESS_BASE_URL%/path-to-page/`. This is to allow for different WordPress URLs to be injected depending on the environment. 
+When linking from Markdown pages in `./src/docs/` to the Cloud WordPress site, use the token `%WORDPRESS_BASE_URL%` in place of the site address and before the path of the document being linked to, in the form `%WORDPRESS_BASE_URL%/path-to-page/`. This is to allow for different WordPress URLs to be injected depending on the environment.
 
 ### FAQs
+
 [Don't write FAQs](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/faqs) or format sections as a question and answer. Just tell the reader what they need to know.
 
 ## Page structure and elements
 
 ### Titles
+
 Use a descriptive and specific title. What does the reader do with the page? What specific information do they gain?
 
 Good titles help with findability and usability.
@@ -100,6 +105,7 @@ Good titles help with findability and usability.
 [Use sentence case](https://www2.gov.bc.ca/gov/content?id=8E987979EA6842D7BDE3EDEEA9331787#case) for titles and headings.
 
 ### Images
+
 Use images sparingly. If you need to use images, make sure they are supplementary to the writing. Don't rely on them to explain a process.
 
 Consider the following before using an image:
@@ -139,6 +145,7 @@ You get the idea. Essentially, when you avoid using their name, it means you avo
 Use the [BC Government's guidelines and tools](https://www2.gov.bc.ca/gov/content/home/accessible-government/toolkit) to ensure your work is accessible and inclusive.
 
 ## Writing step-by-step instructions
+
 Occasionally, you'll have to write procedures. Find some of the most useful tips below but also check out [Microsoft's best practices for instructions](https://docs.microsoft.com/en-us/style-guide/procedures-instructions/). It's a great crash course.
 
 - Use numbered and bullet lists but not multi-level lists. Don't write single-item lists.


### PR DESCRIPTION
This pull request adds a template Markdown document for our team members to copy when they are starting a new document. This is to help make sure the required YAML frontmatter fields get included and to try and enforce some of the style guidelines at the same time. 2cb262c0d915e9d2e6b6a24a1beea11ff78aa960

I reference this new file at the top of the Writing Guide. I also let the linter fix the whitespace in this file. 5fecfdcb32241f412f577282460beb29fa9f6ef7

I've updated the README to reference this template, and also to include additional local development instructions and Nginx configuration information. 739f5ec8cc61e248c7f71ecb253acd2313eb0015

Also, I've included an update to "Vault secrets management" to fix the meta description. 6eab4000da0d3a09a852cd9d8fddaff0219661fa

Tagging @mtspn and @Kolezhanchik so you know I've made these changes, but I'm going to merge and deploy these myself right now. :)