### PR TITLE
Link correction on 3 pages

### DIFF
--- a/src/docs/build-deploy-and-maintain-apps/maintain-an-application.md
+++ b/src/docs/build-deploy-and-maintain-apps/maintain-an-application.md
@@ -112,7 +112,7 @@ Through this reliability and resiliency section you will find:
 * [Recoverability](#recoverability)
 * [Secrets](#secrets)
 * [Storage](#storage)
-* [Periodic HA Testing](periodic-ha-testing)
+* [Periodic HA Testing](#periodic-ha-testing)
 * [CI / CD Pipeline](#cicd-pipeline)
 
 ### Horizontal Pod Autoscalers (HPA)

--- a/src/docs/reusable-code-and-services/reusable-services-list.md
+++ b/src/docs/reusable-code-and-services/reusable-services-list.md
@@ -181,9 +181,8 @@ Related links:
 * [jag-cullencommission repository](https://github.com/bcgov/jag-cullencommission/tree/master/openshift)
 * [Data Catalogue](https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service)
 * [Geocoder API console](https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service)
-* [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15).
-* [BC Address Geocoder Developer Guide](https://developer.gov.bc.ca/Community-Contributed-Content/BC-Address-Geocoder-Developer-Guide)
-* [BC Address Geocoder repository](https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#outputSRS)
+* [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15)
+* [BC Address Geocoder Developer Guide](https://github.com/bcgov/api-specs/blob/master/geocoder/geocoder-developer-guide.md)
 * [Natural Resource Ministry's (NRM) API Store](https://apistore.nrs.gov.bc.ca/store/apis/info?name=dgen-api&version=v1&provider=admin)
 * [Windward](https://www.windwardstudios.com/)
 * [quick-start materials](https://www.windwardstudios.com/resources/quick-start).

--- a/src/docs/security-and-privacy-compliance/devops-security-considerations.md
+++ b/src/docs/security-and-privacy-compliance/devops-security-considerations.md
@@ -314,7 +314,7 @@ Backups help you to recover in the event of a failure or data corruption.  As pa
 - [Database backup best practices](/database-backup-best-practices/)
 
 **GitHub**
-- [GitHub backups](https://github.com/bcgov-c/platform-services-docs/blob/main/github-backups.md)
+- [GitHub backups](https://github.com/bcgov-c/platform-services-docs/blob/main/github/github-backups.md)
 
 ## Change management
 


### PR DESCRIPTION
1. ./reusable-code-and-services/reusable-services-list.md https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md (no longer exists)

2. ./security-and-privacy-compliance/devops-security-considerations.md https://github.com/bcgov-c/platform-services-docs/blob/main/github-backups.md changed to:  https://github.com/bcgov-c/platform-services-docs/blob/main/github/github-backups.md (notice the github directory after main)

3. ./build-deploy-and-maintain-apps/maintain-an-application.md The link to the “periodic-ha-testing” section needed to have a “#” in front of it.