### PR TITLE
Added edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: BC Government Private Cloud Technical Documentation
 docs_dir: src
+repo_url: https://github.com/bcgov/platform-developer-docs
+edit_uri: edit/main/src/
 nav:
 - App monitoring:
   - Onboarding to application monitoring with Sysdig: docs/app-monitoring/sysdig-monitor-onboarding.md


### PR DESCRIPTION
This changes adds an edit button to the documentation pages.

This feature allows a user to either open a GitHub issue or a GitHub PR for a given page.