### PR TITLE
Fix Revision Date

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Build TechDocs
         uses: bcgov/devhub-techdocs-publish@stable
         id: build_and_publish


### PR DESCRIPTION
This is to fix the revision date displayed at the bottom of each page. Currently it displays the date the techdocs build process was run. It should show what date the file was modified. 
