### PR TITLE
Fix bullet points

### DIFF
--- a/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
+++ b/src/docs/openshift-projects-and-access/grant-user-access-openshift.md
@@ -77,6 +77,7 @@ The product owner or a project administrator associated with namespace provision
 Technical leads grant namespace access. For more information, see [Using RBAC to define and apply permissions](https://docs.openshift.com/container-platform/4.9/authentication/using-rbac.html).
 
 Follow these best practices when you grant namespace access to a user:
+
 - For GitHub IDs, enter the username as `mygithubid@github`
 - For IDIR IDs, enter just the government email address that is associated with the IDIR account, such as `john.doe@gov.bc.ca`
 - All usernames on our platform are lowercase. For example, the username `TheBestDev@github` won't work, but `thebestdev@github` does work


### PR DESCRIPTION
The bullet points under the "Grant namespace access" on [Grant user access in OpenShift](https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/openshift-projects-and-access/grant-user-access-openshift/) page are not displaying properly. I've added a linebreak between the sentence and the bullet points so they display properly.
