### PR TITLE
Include legacy authentication option for npm login

### DIFF
--- a/src/docs/build-deploy-and-maintain-apps/push-pull-artifacts-artifactory.md
+++ b/src/docs/build-deploy-and-maintain-apps/push-pull-artifacts-artifactory.md
@@ -141,9 +141,15 @@ $ npm config set registry https://artifacts.developer.gov.bc.ca/artifactory/api/
 
 ```bash
 $ npm login
+Press ENTER to open in the browser...
+```
+
+*To authenticate with an Artifactory Service Account:*
+
+```bash
+$ npm login --auth-type=legacy
 Username: <username>
 Password:
-Email: <username>@<namespace>.local
 ```
 
 3. Once the authentication is complete, you can pull artifacts from this registry:


### PR DESCRIPTION
Since npm v9 there is an `--auth-type` flag on the `npm login` command. The default is `web` which prompts you to press `Enter` to open the web page of the registry you want to authenticate with. This works great if you want to authenticate with Artifactory using keycloak and your own account but does not work with Artifactory service accounts as they can't be used to login to the UI.

If you want to use an Artifactory service account to authenticate, you need to `npm login --auth-type=legacy` which will prompt you for a username and password.