### PR TITLE
added pdb always allow evict

### DIFF
--- a/src/docs/build-deploy-and-maintain-apps/maintain-an-application.md
+++ b/src/docs/build-deploy-and-maintain-apps/maintain-an-application.md
@@ -243,6 +243,7 @@ spec:
   selector:
     matchLabels:
       app: sample-app
+  unhealthyPodEvictionPolicy: AlwaysAllow
 ```
 This assumes that pods in the Deployment or StatefulSet have a label `app` with a value of `sample-app`.
 


### PR DESCRIPTION
tested this in CLAB by messing up readiness probe.

Related to
Update PDB docs with new Unhealthy Eviction Policy#5118

https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/gh/bcdevops/developer-experience/5118