### PR TITLE
Fix typo in Logging page link target

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -50,7 +50,7 @@ demos of their application.
 * [Create alerts and notifications in Sysdig Monitor](docs/app-monitoring/sysdig-monitor-create-alert-channels.md)
 * [Set up advanced metrics in Sysdig Monitor](docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md)
 * [Resource monitoring dashboards](docs/app-monitoring/resource-monitoring-dashboards.md)
-* [Best practices for application logging in OpenShift](docs/app-monitoring/best-pratices-for-application-logging-in-openshift.md)
+* [Best practices for application logging in OpenShift](docs/app-monitoring/best-practices-for-application-logging-in-openshift.md)
 * [Check application health after an outage](docs/app-monitoring/check-application-health-after-outage.md)
 * [Managing resource quotas in Kubernetes: A complete guide](docs/app-monitoring/managing-resource-quotas-in-kubernetes.md)
 * [Sysdig training](docs/app-monitoring/sysdig-training.md)


### PR DESCRIPTION
This PR fixes a typo in the link to the Logging page. Right now, this link is 404ing on DevHub:

<img width="431" alt="logging-1" src="https://github.com/user-attachments/assets/ffcd1dfc-9679-43a2-8483-2768c580f0db">
<img width="668" alt="logging-2" src="https://github.com/user-attachments/assets/af26eb76-ad8a-4c83-b68d-272a7e56f050">
