### PR TITLE
Update openshift-project-resource-quotas.md

### DIFF
--- a/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
+++ b/src/docs/automation-and-resiliency/openshift-project-resource-quotas.md
@@ -21,6 +21,7 @@ sort_order: 4
 Last updated: **January 11, 2024**
 
 New project sets provisioned in **all clusters** of the BC Gov Private Cloud PaaS have the following default resource quotas that include a certain amount of CPU, RAM and storage:
+
 - **CPU**: 0.5 cores as requested, 1.5 cores as the limit
 - **RAM**: 2 GB as requested, 4 GB as the limit
 - **Storage**: 60 PVC count , 1 GB overall storage with 521 MB for backup storage and five snapshots


### PR DESCRIPTION
Added line break so list of default resource quotas renders properly in techdocs.

Currently, it is not displayed as a list, making it harder to read.

Screenshot:

<img width="1120" alt="Screenshot 2024-11-26 at 1 43 11 PM" src="https://github.com/user-attachments/assets/43b4c585-4465-4f27-9095-6f79adae6fc3">
