### PR TITLE
Update mkdocs.yml to fix 404 issue

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@ nav:
   - Onboarding to application monitoring with Sysdig: docs/app-monitoring/sysdig-monitor-onboarding.md
   - Set up a team in Sysdig Monitor: docs/app-monitoring/sysdig-monitor-setup-team.md
   - Create monitoring dashboards in Sysdig Monitor: docs/app-monitoring/sysdig-monitor-create-monitoring-dashboards.md
-  - Create alerts and notifications in Sysdig Monitor: docs/app-monitoring/sysdig-monitor-create-alert-channels.md
   - Set up advanced metrics in Sysdig Monitor: docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md
   - Resource monitoring dashboards: docs/app-monitoring/resource-monitoring-dashboards.md
   - Platform dashboard templates (Sysdig): docs/app-monitoring/sysdig-startup-dashboard-template.md


### PR DESCRIPTION
Clicking the "Create alerts and notifications in Sysdig Monitor" menu item in the "App Monitoring" section of the left hand navigation menu gives a 404 error.

https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/app-monitoring/sysdig-monitor-create-alert-channels.md

The `docs/app-monitoring/sysdig-monitor-create-alert-channels.md` page doesn't exist  

This change removes the "Create alerts and notifications in Sysdig Monitor" from the menu navigation.